### PR TITLE
Simplify lint commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test lint format clean run install-pre-commit-hooks lint-pre-commit
+.PHONY: help install install-dev test lint format clean run install-pre-commit-hooks
 
 # Default target
 help:
@@ -7,8 +7,7 @@ help:
 	@echo "  install-dev              - Install with development dependencies"
 	@echo "  install-pre-commit-hooks - Install pre-commit hooks"
 	@echo "  test                     - Run tests"
-	@echo "  lint                     - Run linting with ruff and mypy"
-	@echo "  lint-pre-commit          - Run pre-commit on all files"
+	@echo "  lint                     - Run pre-commit on all files"
 	@echo "  format                   - Format code with ruff"
 	@echo "  clean                    - Clean build artifacts"
 	@echo "  run                      - Run the CLI"
@@ -33,14 +32,11 @@ install-pre-commit-hooks: install-dev
 	@echo "Pre-commit hooks installed successfully."
 
 # Run pre-commit on all files
-lint-pre-commit: install-dev
+lint: install-dev
 	@echo "Running pre-commit on all files..."
 	uv run pre-commit run --all-files --show-diff-on-failure
 
-# Run linting
-lint:
-	uv run ruff check openhands_cli/
-	uv run mypy openhands_cli/
+
 
 # Format code
 format:

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ This project uses pre-commit hooks to ensure code quality. The following tools a
 
 ```bash
 # Run all pre-commit hooks
-make lint-pre-commit
+make lint
 
-# Run individual linters
-make lint        # Run ruff and mypy
+# Format code
 make format      # Format code with ruff
 ```
 


### PR DESCRIPTION
## Summary

This PR simplifies the linting commands in the Makefile.

- Remove the previous `lint` target that ran `ruff` and `mypy`
- Rename/promote `lint-pre-commit` to `lint` so `make lint` now runs pre-commit on all files
- Update the help text and PHONY targets accordingly
- Update README instructions to reflect the new `make lint` behavior

This change consolidates linting under pre-commit for a simpler developer experience.

Fixes #6

## Changes

- Makefile: deleted the ruff/mypy `lint` target and replaced it with the pre-commit based `lint` target
- README: updated examples under "Running Linters" to use `make lint` and removed `lint-pre-commit`

## Testing

- Verified Makefile targets and help output locally
- CI workflow already uses pre-commit; no changes required there

## Checklist

- [x] I have verified that `make help` reflects the updated commands
- [x] I have verified that `make lint` runs pre-commit checks across the repo
- [x] Documentation updated (README)

## Notes

No application code changes were made; only Makefile and docs were updated.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ead5ed8a1ce147edbbd503c9f05d5abb)