### PR TITLE
Clean README and add Development.md for build/developer guidance

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,110 @@
+# Development Guide
+
+Detailed guidance for contributors working on the OpenHands CLI.
+
+## 1) Managing dependencies with Poetry/uv
+
+This repo includes both pyproject sections for hatch/uv and Poetry for compatibility.
+
+- Add a runtime dependency (using uv):
+  ```bash
+  uv add <package>
+  ```
+- Add a dev dependency (linters, build tools, etc.):
+  ```bash
+  uv add --dev <package>
+  ```
+- Sync environment:
+  ```bash
+  uv sync --extra dev
+  ```
+
+If you use Poetry instead of uv:
+```bash
+poetry add <package>
+poetry add --group dev <package>
+poetry install
+```
+
+Commit the updated pyproject.toml (and lockfile if applicable) with your change.
+
+## 2) Packaging with PyInstaller: spec file tips
+
+PyInstaller uses a spec file (openhands-cli.spec) to describe what to include in the binary.
+Two common knobs when something is missing in the built executable:
+
+- hiddenimports: Python modules that PyInstaller fails to detect automatically.
+  Use when imports are dynamic or optional.
+  Example in spec:
+  ```python
+  hiddenimports=[
+      'openhands_cli.tui',
+      'openhands_cli.pt_style',
+      *collect_submodules('prompt_toolkit'),
+      *collect_submodules('openhands.core'),
+      *collect_submodules('openhands.tools'),
+  ]
+  ```
+
+- datas (a.k.a. data files): Non-Python files required at runtime (templates, config, etc.).
+  Use collect_data_files to include them.
+  Example in spec:
+  ```python
+  datas=[
+      *collect_data_files('tiktoken'),
+      *collect_data_files('openhands.core.agent.codeact_agent', includes=['prompts/*.j2']),
+  ]
+  ```
+
+Differences:
+- hiddenimports is for modules to be packaged as bytecode.
+- datas is for external resource files copied into the bundle.
+
+If a library fails at runtime with "ModuleNotFoundError" inside the binary, add it to hiddenimports.
+If a library complains about missing template/config/resource files, add those paths to datas.
+
+## 3) Build locally and test
+
+- Quick build (recommended):
+  ```bash
+  ./build.sh --install-pyinstaller
+  ```
+  This ensures PyInstaller is present via uv and then runs build.py.
+
+- Manual build:
+  ```bash
+  uv add --dev pyinstaller
+  uv run pyinstaller openhands-cli.spec --clean
+  ```
+
+- Test the binary:
+  ```bash
+  ./dist/openhands-cli            # macOS/Linux
+  # or dist/openhands-cli.exe     # Windows
+  ```
+
+If the binary fails to start:
+- Run the Python entrypoint to confirm the app itself works:
+  ```bash
+  uv run openhands-cli
+  ```
+- Re-run build with --no-clean to inspect build artifacts, or add more hiddenimports/datas.
+
+## 4) Linting and formatting
+
+- Run all pre-commit hooks:
+  ```bash
+  make lint
+  ```
+- Format code:
+  ```bash
+  make format
+  ```
+
+## 5) Notes on agent credentials
+
+To actually converse with a model, export one of the supported keys before running the CLI/binary:
+```bash
+export OPENAI_API_KEY=...   # or
+export LITELLM_API_KEY=...
+```

--- a/README.md
+++ b/README.md
@@ -1,140 +1,45 @@
 # OpenHands CLI
 
-A command-line interface for OpenHands AI Agent with Terminal User Interface (TUI) support.
+A lightweight CLI/TUI to interact with the OpenHands agent (powered by agent-sdk). Build and run locally or as a single executable.
 
-## Development
+## Quickstart
 
-### Setup
+- Prerequisites: Python 3.12+, curl
+- Install uv (package manager):
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Restart your shell so "uv" is on PATH, or follow the installer hint
+  ```
 
-1. Install dependencies:
-   ```bash
-   make install-dev
-   ```
-
-2. Install pre-commit hooks:
-   ```bash
-   make install-pre-commit-hooks
-   ```
-
-### Code Quality
-
-This project uses pre-commit hooks to ensure code quality. The following tools are configured:
-
-- **Ruff**: Fast Python linter and formatter
-- **MyPy**: Static type checking
-- **Pre-commit hooks**: Various code quality checks
-
-#### Running Linters
-
+### Run the CLI locally
 ```bash
-# Run all pre-commit hooks
-make lint
+# Install dependencies (incl. dev tools)
+make install-dev
 
-# Format code
-make format      # Format code with ruff
+# Optional: install pre-commit hooks
+make install-pre-commit-hooks
+
+# Start the CLI
+make run
+# or
+uv run openhands-cli
 ```
 
-#### Pre-commit Hooks
-
-Pre-commit hooks will automatically run on every commit. To run them manually:
-
+Tip: Set your model key (one of) so the agent can talk to an LLM:
 ```bash
-# Run on all files
-uv run pre-commit run --all-files
-
-# Run on staged files only
-uv run pre-commit run
+export OPENAI_API_KEY=...
+# or
+export LITELLM_API_KEY=...
 ```
 
-### Available Commands
-
-Run `make help` to see all available commands:
-
+### Build a standalone executable
 ```bash
-make help
-```
-
-## Binary Packaging
-
-The OpenHands CLI can be packaged into a standalone executable binary using PyInstaller. This allows distribution of the CLI without requiring users to install Python or dependencies.
-
-### Building the Executable
-
-#### Quick Build
-
-Use the provided build script to create a standalone executable:
-
-```bash
-# Using shell script (recommended - handles installation automatically)
+# Build (installs PyInstaller if needed)
 ./build.sh --install-pyinstaller
 
-# Using Python script directly (requires PyInstaller to be pre-installed)
-uv run python build.py
+# The binary will be in dist/
+./dist/openhands-cli            # macOS/Linux
+# dist/openhands-cli.exe        # Windows
 ```
 
-#### Manual Build
-
-You can also build manually using PyInstaller with uv:
-
-```bash
-# Install PyInstaller as dev dependency
-uv add --dev pyinstaller
-
-# Build using the spec file
-uv run pyinstaller openhands-cli.spec --clean
-```
-
-### Build Options
-
-The build script supports several options:
-
-```bash
-# Install PyInstaller and build (shell script handles installation)
-./build.sh --install-pyinstaller
-
-# Build without testing the executable
-./build.sh --install-pyinstaller --no-test
-
-# Build without cleaning previous artifacts
-./build.sh --install-pyinstaller --no-clean
-
-# Use a custom spec file
-./build.sh --install-pyinstaller --spec custom.spec
-
-# Show help
-./build.sh --help
-```
-
-**Note:** The shell script (`build.sh`) automatically handles PyInstaller installation when using the `--install-pyinstaller` flag. The Python script (`build.py`) can be used directly but requires PyInstaller to be pre-installed.
-
-### Output
-
-The build process creates:
-- `dist/openhands-cli` - The standalone executable
-- `build/` - Temporary build files (automatically cleaned)
-
-The executable is typically 10-15 MB and includes all necessary dependencies.
-
-### Testing the Executable
-
-The build script automatically tests the executable, but you can also test manually:
-
-```bash
-# Run the executable
-./dist/openhands-cli
-
-# Check that it displays the CLI interface
-```
-
-### Packaging Configuration
-
-The packaging is configured through:
-- `openhands-cli.spec` - PyInstaller specification file
-- `build.py` - Build automation script
-- `build.sh` - Shell wrapper script
-
-The spec file is optimized for:
-- Single-file executable
-- Minimal size through exclusions
-- All required dependencies included
-- Console application mode
+For advanced development (adding deps, updating the spec file, debugging builds), see Development.md.


### PR DESCRIPTION
Summary
- Rewrite README.md to be concise and action-oriented: quick uv install, local run instructions, and building/using the standalone executable.
- Add Development.md with detailed contributor guidance: managing deps with uv/Poetry, PyInstaller spec usage with hiddenimports vs datas, local build and testing tips, and linting commands.

Why
The previous README accumulated unorganized agent notes across sessions. This change presents a clean, minimal Quickstart, and moves deeper developer content into a dedicated Development.md.

Changes
- README.md:
  - Add Quickstart with uv install
  - Steps to run the CLI locally (make install-dev, make run)
  - Clear binary build and usage section (build.sh --install-pyinstaller, dist/ outputs)
  - Reference to Development.md for advanced details
- Development.md:
  - How to add runtime and dev dependencies (uv and Poetry)
  - Spec file guidance including when to use hiddenimports vs datas
  - Build workflows (scripted and manual) and how to test the executable
  - Lint/format commands and credentials note

Testing
- Ran make lint; all hooks passed (ruff, mypy, pyproject validation, etc.)
- No application code changes; existing tests unaffected

Docs
- README.md fully refreshed
- New Development.md added

Linked issues
- Closes #19

Notes
- No PR template found in this repo; followed standard sections.


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/155d35fbfc324a568220f49767c4942e)