### PR TITLE
Improve TMUX dependency error message for BashExecutor setup

### DIFF
--- a/tests/test_agent_chat.py
+++ b/tests/test_agent_chat.py
@@ -1,0 +1,56 @@
+"""Tests for agent chat error handling and setup behavior."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from libtmux.exc import TmuxCommandNotFound
+
+
+class TestAgentChatTmuxHandling:
+    """Test friendly error handling when tmux is missing."""
+
+    @patch.dict(os.environ, {"LITELLM_API_KEY": "dummy-key"}, clear=False)
+    @patch("openhands_cli.agent_chat.print_formatted_text")
+    @patch("openhands_cli.agent_chat.BashExecutor", side_effect=TmuxCommandNotFound)
+    @patch("openhands_cli.agent_chat.LLM")
+    def test_setup_agent_handles_missing_tmux(
+        self,
+        mock_llm: MagicMock,
+        _mock_bash: MagicMock,
+        mock_print: MagicMock,
+    ) -> None:
+        """setup_agent should catch TmuxCommandNotFound and print helpful guidance."""
+        from openhands_cli.agent_chat import setup_agent
+
+        llm, agent, conv = setup_agent()
+
+        assert (llm, agent, conv) == (None, None, None)
+
+        # Combine printed HTML strings for assertion
+        printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+        assert "tmux is not installed or not found in PATH" in printed
+        assert "requires tmux" in printed
+        assert "Install examples" in printed
+
+    @patch.dict(os.environ, {"LITELLM_API_KEY": "dummy-key"}, clear=False)
+    @patch("openhands_cli.agent_chat.print_formatted_text")
+    @patch(
+        "openhands_cli.agent_chat.BashExecutor",
+        side_effect=Exception("TmuxCommandNotFound"),
+    )
+    @patch("openhands_cli.agent_chat.LLM")
+    def test_setup_agent_handles_missing_tmux_by_name(
+        self,
+        mock_llm: MagicMock,
+        _mock_bash: MagicMock,
+        mock_print: MagicMock,
+    ) -> None:
+        """Also handle when only the exception class name matches (defensive)."""
+        from openhands_cli.agent_chat import setup_agent
+
+        llm, agent, conv = setup_agent()
+
+        assert (llm, agent, conv) == (None, None, None)
+        printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+        assert "tmux is not installed or not found in PATH" in printed


### PR DESCRIPTION
Summary
- Implements a friendly, actionable error message when tmux is not installed or not found in PATH during BashExecutor initialization.
- Prevents a noisy stack trace and clearly explains that tmux is required locally for the CLI to manage shell sessions.
- Adds unit tests to ensure this behavior is covered and remains stable.

What is the change?
- In openhands_cli/agent_chat.py, wrap BashExecutor initialization in a try/except block.
- Detect libtmux.exc.TmuxCommandNotFound (and similar cases) and print a clear guidance message, including installation examples for macOS and popular Linux distros.
- Return gracefully without proceeding to agent startup when tmux is missing.

Why is this change needed?
- Fixes #14 by replacing an unhelpful stack trace with a user-friendly message that explains the requirement and how to install tmux locally.

How is this tested?
- Added tests/tests_agent_chat.py:
  - test_setup_agent_handles_missing_tmux: Mocks BashExecutor to raise TmuxCommandNotFound and asserts the friendly messages are printed and setup_agent returns (None, None, None).
  - test_setup_agent_handles_missing_tmux_by_name: Ensures we also catch cases where the exception type may not be importable but the name/message indicates tmux is missing.
- All tests pass locally: 13 passed.

Related issues
- Fixes #14

Checklist
- [x] Code compiles and is formatted (ruff/black)
- [x] Lint passes (pre-commit)
- [x] Unit tests added and passing
- [x] Does not change public API

Additional notes
- No documentation changes required. The behavior is self-explanatory in the CLI output.


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6aa488bd69e14841a8ecbc3840df91c4)