### PR TITLE
Add modern typing requirement to repo.md

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -20,6 +20,9 @@ To set up the development environment:
 ## Linting Requirements
 **Always run lint before committing changes.** Use `make lint` to run all pre-commit hooks on all files. The project uses:
 
+## Typing Requirements
+When using types, prefer modern typing syntax (e.g., use `| None` instead of `Optional`).
+
 ## Documentation Guidelines
 - **Do NOT send summary updates in the README.md** for the repository
 - **Do NOT create .md files in the root** of the repository to track or send updates


### PR DESCRIPTION
## Summary
This PR adds a concise sentence to the repo.md file stating the requirement to use modern typing syntax when working with types in the codebase.

## Changes
- Added a new "Typing Requirements" section to the Development Guidelines in `.openhands/microagents/repo.md`
- Specifically mentions preferring `| None` over `Optional` as an example of modern typing syntax

## Issue
Fixes #23

## Testing
This is a documentation-only change, so no additional tests are required.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7e251128a2734adfa4d96342c8f3eb4a)