### PR TITLE
Add repo.md with instructions for updating agent-sdk SHA

### DIFF
--- a/repo.md
+++ b/repo.md
@@ -1,0 +1,13 @@
+# Repository Instructions
+
+## Updating Agent-SDK SHA
+
+If the user says something along the lines of "update the sha" or "update the agent-sdk sha", you need to:
+
+1. Use the `$GITHUB_TOKEN` to get the latest commit from the agent-sdk repository
+2. Update the poetry toml file with the new SHA
+3. Regenerate the uv lock file
+4. Run `./build.sh` to confirm that the build still works
+5. Open a pull request with the changes
+
+If the build fails, still open the pull request and explain what error you're seeing, and the steps you plan to take to fix it; don't fix it yet though.


### PR DESCRIPTION
## Summary

This PR adds a `repo.md` file with concise instructions for updating the agent-sdk SHA, as requested in issue #28.

## Changes

- Created `repo.md` file with step-by-step instructions for updating agent-sdk SHA
- Instructions include:
  - Using `$GITHUB_TOKEN` to get the latest commit
  - Updating the poetry toml file
  - Regenerating the uv lock file
  - Running `./build.sh` to confirm build works
  - Opening a pull request with changes
  - Handling build failures appropriately

## Testing

This is a documentation-only change, no tests required.

Fixes #28

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f53e3042fa224884bc4bc0a8751cff7e)