### PR TITLE
Add confirmation mode to CLI

### DIFF
--- a/openhands_cli/agent_chat.py
+++ b/openhands_cli/agent_chat.py
@@ -269,7 +269,7 @@ class ConversationRunner:
         if pending_actions:
             approved = ask_user_confirmation(pending_actions)
             if not approved:
-                self._reject_pending_actions("User rejected the actions")
+                self.conversation.reject_pending_actions("User rejected the actions")
                 return False
             return True
         else:
@@ -281,14 +281,6 @@ class ConversationRunner:
             )
             self.conversation.state.waiting_for_confirmation = False
             return True
-
-    def _reject_pending_actions(self, reason: str) -> None:
-        """Reject pending actions with reason.
-
-        Args:
-            reason: Reason for rejecting the actions
-        """
-        self.conversation.reject_pending_actions(reason)
 
 
 def display_welcome(session_id: str = "chat") -> None:

--- a/openhands_cli/agent_chat.py
+++ b/openhands_cli/agent_chat.py
@@ -32,6 +32,7 @@ try:
         TextContent,
         Tool,
     )
+    from openhands.sdk.event.utils import get_unmatched_actions
     from openhands.tools import (
         BashExecutor,
         FileEditorExecutor,
@@ -214,7 +215,7 @@ class ConversationRunner:
             self.conversation.run()
 
             # Check if agent is waiting for confirmation
-            if self.conversation.state.waiting_for_confirmation:
+            if self.conversation.state.agent_waiting_for_confirmation:
                 if not self._handle_confirmation_request():
                     # User rejected - continue the loop as agent may produce new actions or finish
                     continue
@@ -229,7 +230,7 @@ class ConversationRunner:
         Returns:
             True if user approved actions, False if rejected
         """
-        pending_actions = self.conversation.get_pending_actions()
+        pending_actions = get_unmatched_actions(self.conversation.state.events)
 
         if pending_actions:
             approved = ask_user_confirmation(pending_actions)

--- a/openhands_cli/agent_chat.py
+++ b/openhands_cli/agent_chat.py
@@ -236,16 +236,7 @@ class ConversationRunner:
             if not approved:
                 self.conversation.reject_pending_actions("User rejected the actions")
                 return False
-            return True
-        else:
-            # Defensive: clear the flag if somehow set without actions
-            print_formatted_text(
-                HTML(
-                    "<yellow>⚠️ Agent is waiting for confirmation but no pending actions were found.</yellow>"
-                )
-            )
-            self.conversation.state.waiting_for_confirmation = False
-            return True
+        return True
 
 
 def display_welcome(session_id: str = "chat") -> None:

--- a/openhands_cli/tui.py
+++ b/openhands_cli/tui.py
@@ -16,6 +16,7 @@ COMMANDS = {
     "/help": "Display available commands",
     "/clear": "Clear the screen",
     "/status": "Display conversation details",
+    "/confirm": "Toggle confirmation mode on/off",
     "/new": "Create a new conversation",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@ab8980714dd397f26fe811227afbc533c59fae70#subdirectory=openhands/sdk",
-  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@ab8980714dd397f26fe811227afbc533c59fae70#subdirectory=openhands/tools",
+  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@e8f946380e4281ec5b92c21d0f284e322f5a07db#subdirectory=openhands/sdk",
+  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@e8f946380e4281ec5b92c21d0f284e322f5a07db#subdirectory=openhands/tools",
   "prompt-toolkit>=3",
 ]
 
@@ -52,8 +52,8 @@ packages = [ { include = "openhands_cli" } ]
 [tool.poetry.dependencies]
 python = "^3.12"
 prompt-toolkit = "^3.0.0"
-openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "ab8980714dd397f26fe811227afbc533c59fae70", subdirectory = "openhands/sdk" }
-openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "ab8980714dd397f26fe811227afbc533c59fae70", subdirectory = "openhands/tools" }
+openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "e8f946380e4281ec5b92c21d0f284e322f5a07db", subdirectory = "openhands/sdk" }
+openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "e8f946380e4281ec5b92c21d0f284e322f5a07db", subdirectory = "openhands/tools" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@e8f946380e4281ec5b92c21d0f284e322f5a07db#subdirectory=openhands/sdk",
-  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@e8f946380e4281ec5b92c21d0f284e322f5a07db#subdirectory=openhands/tools",
+  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f#subdirectory=openhands/sdk",
+  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f#subdirectory=openhands/tools",
   "prompt-toolkit>=3",
 ]
 
@@ -52,8 +52,8 @@ packages = [ { include = "openhands_cli" } ]
 [tool.poetry.dependencies]
 python = "^3.12"
 prompt-toolkit = "^3.0.0"
-openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "e8f946380e4281ec5b92c21d0f284e322f5a07db", subdirectory = "openhands/sdk" }
-openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "e8f946380e4281ec5b92c21d0f284e322f5a07db", subdirectory = "openhands/tools" }
+openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f", subdirectory = "openhands/sdk" }
+openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f", subdirectory = "openhands/tools" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"

--- a/tests/test_confirmation_mode.py
+++ b/tests/test_confirmation_mode.py
@@ -4,10 +4,7 @@ Tests for confirmation mode functionality in OpenHands CLI.
 """
 
 import os
-import unittest.mock
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from openhands_cli.agent_chat import ask_user_confirmation, setup_agent
 
@@ -17,80 +14,79 @@ class TestConfirmationMode:
 
     def test_confirmation_mode_env_var_true(self):
         """Test that CONFIRMATION_MODE=true enables confirmation mode."""
-        with patch.dict(os.environ, {
-            "CONFIRMATION_MODE": "true",
-            "LITELLM_API_KEY": "test-key"
-        }):
-            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
-                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
-                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
-                 patch("openhands_cli.agent_chat.BashExecutor"), \
-                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
-                
+        with patch.dict(
+            os.environ, {"CONFIRMATION_MODE": "true", "LITELLM_API_KEY": "test-key"}
+        ):
+            with (
+                patch("openhands_cli.agent_chat.LLM"),
+                patch("openhands_cli.agent_chat.Agent"),
+                patch("openhands_cli.agent_chat.Conversation") as mock_conversation,
+                patch("openhands_cli.agent_chat.BashExecutor"),
+                patch("openhands_cli.agent_chat.FileEditorExecutor"),
+            ):
                 mock_conv_instance = MagicMock()
                 mock_conversation.return_value = mock_conv_instance
-                
+
                 llm, agent, conversation = setup_agent()
-                
+
                 # Verify confirmation mode was enabled
                 mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
 
     def test_confirmation_mode_env_var_1(self):
         """Test that CONFIRMATION_MODE=1 enables confirmation mode."""
-        with patch.dict(os.environ, {
-            "CONFIRMATION_MODE": "1",
-            "LITELLM_API_KEY": "test-key"
-        }):
-            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
-                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
-                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
-                 patch("openhands_cli.agent_chat.BashExecutor"), \
-                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
-                
+        with patch.dict(
+            os.environ, {"CONFIRMATION_MODE": "1", "LITELLM_API_KEY": "test-key"}
+        ):
+            with (
+                patch("openhands_cli.agent_chat.LLM"),
+                patch("openhands_cli.agent_chat.Agent"),
+                patch("openhands_cli.agent_chat.Conversation") as mock_conversation,
+                patch("openhands_cli.agent_chat.BashExecutor"),
+                patch("openhands_cli.agent_chat.FileEditorExecutor"),
+            ):
                 mock_conv_instance = MagicMock()
                 mock_conversation.return_value = mock_conv_instance
-                
+
                 llm, agent, conversation = setup_agent()
-                
+
                 # Verify confirmation mode was enabled
                 mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
 
     def test_confirmation_mode_env_var_false(self):
         """Test that CONFIRMATION_MODE=false does not enable confirmation mode."""
-        with patch.dict(os.environ, {
-            "CONFIRMATION_MODE": "false",
-            "LITELLM_API_KEY": "test-key"
-        }):
-            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
-                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
-                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
-                 patch("openhands_cli.agent_chat.BashExecutor"), \
-                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
-                
+        with patch.dict(
+            os.environ, {"CONFIRMATION_MODE": "false", "LITELLM_API_KEY": "test-key"}
+        ):
+            with (
+                patch("openhands_cli.agent_chat.LLM"),
+                patch("openhands_cli.agent_chat.Agent"),
+                patch("openhands_cli.agent_chat.Conversation") as mock_conversation,
+                patch("openhands_cli.agent_chat.BashExecutor"),
+                patch("openhands_cli.agent_chat.FileEditorExecutor"),
+            ):
                 mock_conv_instance = MagicMock()
                 mock_conversation.return_value = mock_conv_instance
-                
+
                 llm, agent, conversation = setup_agent()
-                
+
                 # Verify confirmation mode was not enabled
                 mock_conv_instance.set_confirmation_mode.assert_not_called()
 
     def test_confirmation_mode_env_var_not_set(self):
         """Test that confirmation mode is not enabled when env var is not set."""
-        with patch.dict(os.environ, {
-            "LITELLM_API_KEY": "test-key"
-        }, clear=True):
-            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
-                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
-                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
-                 patch("openhands_cli.agent_chat.BashExecutor"), \
-                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
-                
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "test-key"}, clear=True):
+            with (
+                patch("openhands_cli.agent_chat.LLM"),
+                patch("openhands_cli.agent_chat.Agent"),
+                patch("openhands_cli.agent_chat.Conversation") as mock_conversation,
+                patch("openhands_cli.agent_chat.BashExecutor"),
+                patch("openhands_cli.agent_chat.FileEditorExecutor"),
+            ):
                 mock_conv_instance = MagicMock()
                 mock_conversation.return_value = mock_conv_instance
-                
+
                 llm, agent, conversation = setup_agent()
-                
+
                 # Verify confirmation mode was not enabled
                 mock_conv_instance.set_confirmation_mode.assert_not_called()
 
@@ -105,11 +101,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.return_value = "yes"
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "ls -la"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is True
 
@@ -119,11 +115,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.return_value = "no"
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "rm -rf /"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is False
 
@@ -133,11 +129,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.return_value = "y"
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "echo hello"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is True
 
@@ -147,11 +143,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.return_value = "n"
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "dangerous command"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is False
 
@@ -161,11 +157,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.side_effect = ["invalid", "maybe", "yes"]
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "echo test"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is True
         assert mock_session.prompt.call_count == 3
@@ -176,11 +172,11 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.side_effect = KeyboardInterrupt()
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "echo test"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is False
 
@@ -190,33 +186,36 @@ class TestConfirmationMode:
         mock_session = MagicMock()
         mock_session.prompt.side_effect = EOFError()
         mock_prompt_session.return_value = mock_session
-        
+
         mock_action = MagicMock()
         mock_action.tool_name = "bash"
         mock_action.action = "echo test"
-        
+
         result = ask_user_confirmation([mock_action])
         assert result is False
 
     def test_ask_user_confirmation_multiple_actions(self):
         """Test that ask_user_confirmation displays multiple actions correctly."""
-        with patch("openhands_cli.agent_chat.PromptSession") as mock_prompt_session, \
-             patch("openhands_cli.agent_chat.print_formatted_text") as mock_print:
-            
+        with (
+            patch("openhands_cli.agent_chat.PromptSession") as mock_prompt_session,
+            patch("openhands_cli.agent_chat.print_formatted_text") as mock_print,
+        ):
             mock_session = MagicMock()
             mock_session.prompt.return_value = "yes"
             mock_prompt_session.return_value = mock_session
-            
+
             mock_action1 = MagicMock()
             mock_action1.tool_name = "bash"
             mock_action1.action = "ls -la"
-            
+
             mock_action2 = MagicMock()
             mock_action2.tool_name = "str_replace_editor"
             mock_action2.action = "create file.txt"
-            
+
             result = ask_user_confirmation([mock_action1, mock_action2])
             assert result is True
-            
+
             # Verify that both actions were displayed
-            assert mock_print.call_count >= 3  # Header + 2 actions + at least approval message
+            assert (
+                mock_print.call_count >= 3
+            )  # Header + 2 actions + at least approval message

--- a/tests/test_confirmation_mode.py
+++ b/tests/test_confirmation_mode.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Tests for confirmation mode functionality in OpenHands CLI.
+"""
+
+import os
+import unittest.mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands_cli.agent_chat import ask_user_confirmation, setup_agent
+
+
+class TestConfirmationMode:
+    """Test suite for confirmation mode functionality."""
+
+    def test_confirmation_mode_env_var_true(self):
+        """Test that CONFIRMATION_MODE=true enables confirmation mode."""
+        with patch.dict(os.environ, {
+            "CONFIRMATION_MODE": "true",
+            "LITELLM_API_KEY": "test-key"
+        }):
+            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
+                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
+                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
+                 patch("openhands_cli.agent_chat.BashExecutor"), \
+                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
+                
+                mock_conv_instance = MagicMock()
+                mock_conversation.return_value = mock_conv_instance
+                
+                llm, agent, conversation = setup_agent()
+                
+                # Verify confirmation mode was enabled
+                mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
+
+    def test_confirmation_mode_env_var_1(self):
+        """Test that CONFIRMATION_MODE=1 enables confirmation mode."""
+        with patch.dict(os.environ, {
+            "CONFIRMATION_MODE": "1",
+            "LITELLM_API_KEY": "test-key"
+        }):
+            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
+                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
+                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
+                 patch("openhands_cli.agent_chat.BashExecutor"), \
+                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
+                
+                mock_conv_instance = MagicMock()
+                mock_conversation.return_value = mock_conv_instance
+                
+                llm, agent, conversation = setup_agent()
+                
+                # Verify confirmation mode was enabled
+                mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
+
+    def test_confirmation_mode_env_var_false(self):
+        """Test that CONFIRMATION_MODE=false does not enable confirmation mode."""
+        with patch.dict(os.environ, {
+            "CONFIRMATION_MODE": "false",
+            "LITELLM_API_KEY": "test-key"
+        }):
+            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
+                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
+                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
+                 patch("openhands_cli.agent_chat.BashExecutor"), \
+                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
+                
+                mock_conv_instance = MagicMock()
+                mock_conversation.return_value = mock_conv_instance
+                
+                llm, agent, conversation = setup_agent()
+                
+                # Verify confirmation mode was not enabled
+                mock_conv_instance.set_confirmation_mode.assert_not_called()
+
+    def test_confirmation_mode_env_var_not_set(self):
+        """Test that confirmation mode is not enabled when env var is not set."""
+        with patch.dict(os.environ, {
+            "LITELLM_API_KEY": "test-key"
+        }, clear=True):
+            with patch("openhands_cli.agent_chat.LLM") as mock_llm, \
+                 patch("openhands_cli.agent_chat.Agent") as mock_agent, \
+                 patch("openhands_cli.agent_chat.Conversation") as mock_conversation, \
+                 patch("openhands_cli.agent_chat.BashExecutor"), \
+                 patch("openhands_cli.agent_chat.FileEditorExecutor"):
+                
+                mock_conv_instance = MagicMock()
+                mock_conversation.return_value = mock_conv_instance
+                
+                llm, agent, conversation = setup_agent()
+                
+                # Verify confirmation mode was not enabled
+                mock_conv_instance.set_confirmation_mode.assert_not_called()
+
+    def test_ask_user_confirmation_empty_actions(self):
+        """Test that ask_user_confirmation returns True for empty actions list."""
+        result = ask_user_confirmation([])
+        assert result is True
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_yes(self, mock_prompt_session):
+        """Test that ask_user_confirmation returns True when user says yes."""
+        mock_session = MagicMock()
+        mock_session.prompt.return_value = "yes"
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "ls -la"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is True
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_no(self, mock_prompt_session):
+        """Test that ask_user_confirmation returns False when user says no."""
+        mock_session = MagicMock()
+        mock_session.prompt.return_value = "no"
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "rm -rf /"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is False
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_y_shorthand(self, mock_prompt_session):
+        """Test that ask_user_confirmation accepts 'y' as yes."""
+        mock_session = MagicMock()
+        mock_session.prompt.return_value = "y"
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "echo hello"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is True
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_n_shorthand(self, mock_prompt_session):
+        """Test that ask_user_confirmation accepts 'n' as no."""
+        mock_session = MagicMock()
+        mock_session.prompt.return_value = "n"
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "dangerous command"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is False
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_invalid_then_yes(self, mock_prompt_session):
+        """Test that ask_user_confirmation handles invalid input then accepts yes."""
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = ["invalid", "maybe", "yes"]
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "echo test"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is True
+        assert mock_session.prompt.call_count == 3
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_keyboard_interrupt(self, mock_prompt_session):
+        """Test that ask_user_confirmation handles KeyboardInterrupt gracefully."""
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = KeyboardInterrupt()
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "echo test"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is False
+
+    @patch("openhands_cli.agent_chat.PromptSession")
+    def test_ask_user_confirmation_eof_error(self, mock_prompt_session):
+        """Test that ask_user_confirmation handles EOFError gracefully."""
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = EOFError()
+        mock_prompt_session.return_value = mock_session
+        
+        mock_action = MagicMock()
+        mock_action.tool_name = "bash"
+        mock_action.action = "echo test"
+        
+        result = ask_user_confirmation([mock_action])
+        assert result is False
+
+    def test_ask_user_confirmation_multiple_actions(self):
+        """Test that ask_user_confirmation displays multiple actions correctly."""
+        with patch("openhands_cli.agent_chat.PromptSession") as mock_prompt_session, \
+             patch("openhands_cli.agent_chat.print_formatted_text") as mock_print:
+            
+            mock_session = MagicMock()
+            mock_session.prompt.return_value = "yes"
+            mock_prompt_session.return_value = mock_session
+            
+            mock_action1 = MagicMock()
+            mock_action1.tool_name = "bash"
+            mock_action1.action = "ls -la"
+            
+            mock_action2 = MagicMock()
+            mock_action2.tool_name = "str_replace_editor"
+            mock_action2.action = "create file.txt"
+            
+            result = ask_user_confirmation([mock_action1, mock_action2])
+            assert result is True
+            
+            # Verify that both actions were displayed
+            assert mock_print.call_count >= 3  # Header + 2 actions + at least approval message

--- a/tests/test_confirmation_mode.py
+++ b/tests/test_confirmation_mode.py
@@ -4,6 +4,7 @@ Tests for confirmation mode functionality in OpenHands CLI.
 """
 
 import os
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from openhands_cli.agent_chat import ask_user_confirmation, setup_agent
@@ -12,7 +13,7 @@ from openhands_cli.agent_chat import ask_user_confirmation, setup_agent
 class TestConfirmationMode:
     """Test suite for confirmation mode functionality."""
 
-    def test_confirmation_mode_env_var_true(self):
+    def test_confirmation_mode_env_var_true(self) -> None:
         """Test that CONFIRMATION_MODE=true enables confirmation mode."""
         with patch.dict(
             os.environ, {"CONFIRMATION_MODE": "true", "LITELLM_API_KEY": "test-key"}
@@ -32,7 +33,7 @@ class TestConfirmationMode:
                 # Verify confirmation mode was enabled
                 mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
 
-    def test_confirmation_mode_env_var_1(self):
+    def test_confirmation_mode_env_var_1(self) -> None:
         """Test that CONFIRMATION_MODE=1 enables confirmation mode."""
         with patch.dict(
             os.environ, {"CONFIRMATION_MODE": "1", "LITELLM_API_KEY": "test-key"}
@@ -52,7 +53,7 @@ class TestConfirmationMode:
                 # Verify confirmation mode was enabled
                 mock_conv_instance.set_confirmation_mode.assert_called_once_with(True)
 
-    def test_confirmation_mode_env_var_false(self):
+    def test_confirmation_mode_env_var_false(self) -> None:
         """Test that CONFIRMATION_MODE=false does not enable confirmation mode."""
         with patch.dict(
             os.environ, {"CONFIRMATION_MODE": "false", "LITELLM_API_KEY": "test-key"}
@@ -72,7 +73,7 @@ class TestConfirmationMode:
                 # Verify confirmation mode was not enabled
                 mock_conv_instance.set_confirmation_mode.assert_not_called()
 
-    def test_confirmation_mode_env_var_not_set(self):
+    def test_confirmation_mode_env_var_not_set(self) -> None:
         """Test that confirmation mode is not enabled when env var is not set."""
         with patch.dict(os.environ, {"LITELLM_API_KEY": "test-key"}, clear=True):
             with (
@@ -90,13 +91,13 @@ class TestConfirmationMode:
                 # Verify confirmation mode was not enabled
                 mock_conv_instance.set_confirmation_mode.assert_not_called()
 
-    def test_ask_user_confirmation_empty_actions(self):
+    def test_ask_user_confirmation_empty_actions(self) -> None:
         """Test that ask_user_confirmation returns True for empty actions list."""
         result = ask_user_confirmation([])
         assert result is True
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_yes(self, mock_prompt_session):
+    def test_ask_user_confirmation_yes(self, mock_prompt_session: Any) -> None:
         """Test that ask_user_confirmation returns True when user says yes."""
         mock_session = MagicMock()
         mock_session.prompt.return_value = "yes"
@@ -110,7 +111,7 @@ class TestConfirmationMode:
         assert result is True
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_no(self, mock_prompt_session):
+    def test_ask_user_confirmation_no(self, mock_prompt_session: Any) -> None:
         """Test that ask_user_confirmation returns False when user says no."""
         mock_session = MagicMock()
         mock_session.prompt.return_value = "no"
@@ -124,7 +125,7 @@ class TestConfirmationMode:
         assert result is False
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_y_shorthand(self, mock_prompt_session):
+    def test_ask_user_confirmation_y_shorthand(self, mock_prompt_session: Any) -> None:
         """Test that ask_user_confirmation accepts 'y' as yes."""
         mock_session = MagicMock()
         mock_session.prompt.return_value = "y"
@@ -138,7 +139,7 @@ class TestConfirmationMode:
         assert result is True
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_n_shorthand(self, mock_prompt_session):
+    def test_ask_user_confirmation_n_shorthand(self, mock_prompt_session: Any) -> None:
         """Test that ask_user_confirmation accepts 'n' as no."""
         mock_session = MagicMock()
         mock_session.prompt.return_value = "n"
@@ -152,7 +153,9 @@ class TestConfirmationMode:
         assert result is False
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_invalid_then_yes(self, mock_prompt_session):
+    def test_ask_user_confirmation_invalid_then_yes(
+        self, mock_prompt_session: Any
+    ) -> None:
         """Test that ask_user_confirmation handles invalid input then accepts yes."""
         mock_session = MagicMock()
         mock_session.prompt.side_effect = ["invalid", "maybe", "yes"]
@@ -167,7 +170,9 @@ class TestConfirmationMode:
         assert mock_session.prompt.call_count == 3
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_keyboard_interrupt(self, mock_prompt_session):
+    def test_ask_user_confirmation_keyboard_interrupt(
+        self, mock_prompt_session: Any
+    ) -> None:
         """Test that ask_user_confirmation handles KeyboardInterrupt gracefully."""
         mock_session = MagicMock()
         mock_session.prompt.side_effect = KeyboardInterrupt()
@@ -181,7 +186,7 @@ class TestConfirmationMode:
         assert result is False
 
     @patch("openhands_cli.agent_chat.PromptSession")
-    def test_ask_user_confirmation_eof_error(self, mock_prompt_session):
+    def test_ask_user_confirmation_eof_error(self, mock_prompt_session: Any) -> None:
         """Test that ask_user_confirmation handles EOFError gracefully."""
         mock_session = MagicMock()
         mock_session.prompt.side_effect = EOFError()
@@ -194,7 +199,7 @@ class TestConfirmationMode:
         result = ask_user_confirmation([mock_action])
         assert result is False
 
-    def test_ask_user_confirmation_multiple_actions(self):
+    def test_ask_user_confirmation_multiple_actions(self) -> None:
         """Test that ask_user_confirmation displays multiple actions correctly."""
         with (
             patch("openhands_cli.agent_chat.PromptSession") as mock_prompt_session,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -74,7 +74,7 @@ class TestCommandCompleter:
 
 def test_commands_dict() -> None:
     """Test that COMMANDS dictionary contains expected commands."""
-    expected_commands = {"/exit", "/help", "/clear", "/status", "/new"}
+    expected_commands = {"/exit", "/help", "/clear", "/status", "/confirm", "/new"}
     assert set(COMMANDS.keys()) == expected_commands
 
     # Check that all commands have descriptions

--- a/uv.lock
+++ b/uv.lock
@@ -1197,8 +1197,8 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1" },
-    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=ab8980714dd397f26fe811227afbc533c59fae70" },
-    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=ab8980714dd397f26fe811227afbc533c59fae70" },
+    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db" },
+    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
@@ -1216,7 +1216,7 @@ dev = [
 [[package]]
 name = "openhands-sdk"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=ab8980714dd397f26fe811227afbc533c59fae70#ab8980714dd397f26fe811227afbc533c59fae70" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db#e8f946380e4281ec5b92c21d0f284e322f5a07db" }
 dependencies = [
     { name = "fastmcp" },
     { name = "litellm" },
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "openhands-tools"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=ab8980714dd397f26fe811227afbc533c59fae70#ab8980714dd397f26fe811227afbc533c59fae70" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db#e8f946380e4281ec5b92c21d0f284e322f5a07db" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.12.0"
+version = "2.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -435,7 +435,6 @@ dependencies = [
     { name = "exceptiongroup" },
     { name = "httpx" },
     { name = "mcp" },
-    { name = "openai" },
     { name = "openapi-core" },
     { name = "openapi-pydantic" },
     { name = "pydantic", extra = ["email"] },
@@ -443,9 +442,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b0/c3b6521e14d284e49729826f6add9ea3af7f35425d7de29727c08545d1c8/fastmcp-2.12.0.tar.gz", hash = "sha256:c7d6ec0fe3fa8d10061d08b40ebf6a4f916034a47ff3188dfd81c25e143ac18e", size = 5241089, upload-time = "2025-08-31T11:48:18.823Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/8a/c46759bb41a53187191e5b3d963c0bde54783ecc89186a93c4947607b8e4/fastmcp-2.12.2.tar.gz", hash = "sha256:6d13e2f9be57b99763fc22485f9f603daa23bfbca35a8172baa43b283d6fc1ff", size = 5244547, upload-time = "2025-09-03T21:28:09.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/e5/8fc0fbc6518469dbecbcc6e5f94f2d36f116c5dd9f2faf4100244b0b119c/fastmcp-2.12.0-py3-none-any.whl", hash = "sha256:f57d4a32b7761da3a4842ba8d70cf1b1a6c3791eda27fd3252780ecfa8f87cff", size = 312676, upload-time = "2025-08-31T11:48:17.366Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/7a8d564b1b9909dbfc36eb93d76410a4acfada6b1e13ee451a753bb6dbc2/fastmcp-2.12.2-py3-none-any.whl", hash = "sha256:0b58d68e819c82078d1fd51989d3d81f2be7382d527308b06df55f4d0a4ec94f", size = 312029, upload-time = "2025-09-03T21:28:08.62Z" },
 ]
 
 [[package]]
@@ -838,7 +837,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.76.1"
+version = "1.76.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -854,9 +853,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/fd/aa87c0a598377786521bee585f4d525e846f5339b816903298bfbb9daef5/litellm-1.76.1.tar.gz", hash = "sha256:d5a3a3efda04999b60ec0d1c29c1eaaa12f89a7b29db4bda691c7fb55b4fa6ad", size = 10178100, upload-time = "2025-08-30T21:05:48.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a3/f7c00c660972eed1ba5ed53771ac9b4235e7fb1dc410e91d35aff2778ae7/litellm-1.76.2.tar.gz", hash = "sha256:fc7af111fa0f06943d8dbebed73f88000f9902f0d0ee0882c57d0bd5c1a37ecb", size = 10189238, upload-time = "2025-09-04T00:25:09.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/d3/16423b6d399540eeff357f00abc85f62dc337d347a0c98ccadc448a61df5/litellm-1.76.1-py3-none-any.whl", hash = "sha256:938f05075372f26098211ea9b3cb0a6bb7b46111330226b70d42d40bd307812f", size = 8965465, upload-time = "2025-08-30T21:05:46.068Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f4/980cc81c21424026dcb48a541654fd6f4286891825a3d0dd51f02b65cbc3/litellm-1.76.2-py3-none-any.whl", hash = "sha256:a9a2ef64a598b5b4ae245f1de6afc400856477cd6f708ff633d95e2275605a45", size = 8973847, upload-time = "2025-09-04T00:25:05.353Z" },
 ]
 
 [[package]]
@@ -1085,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.105.0"
+version = "1.106.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1097,9 +1096,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/a9/c8c2dea8066a8f3079f69c242f7d0d75aaad4c4c3431da5b0df22a24e75d/openai-1.105.0.tar.gz", hash = "sha256:a68a47adce0506d34def22dd78a42cbb6cfecae1cf6a5fe37f38776d32bbb514", size = 557265, upload-time = "2025-09-03T14:14:08.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b6/1aff7d6b8e9f0c3ac26bfbb57b9861a6711d5d60bd7dd5f7eebbf80509b7/openai-1.106.1.tar.gz", hash = "sha256:5f575967e3a05555825c43829cdcd50be6e49ab6a3e5262f0937a3f791f917f1", size = 561095, upload-time = "2025-09-04T18:17:15.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/01/186845829d3a3609bb5b474067959076244dd62540d3e336797319b13924/openai-1.105.0-py3-none-any.whl", hash = "sha256:3ad7635132b0705769ccae31ca7319f59ec0c7d09e94e5e713ce2d130e5b021f", size = 928203, upload-time = "2025-09-03T14:14:06.842Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e1/47887212baa7bc0532880d33d5eafbdb46fcc4b53789b903282a74a85b5b/openai-1.106.1-py3-none-any.whl", hash = "sha256:bfdef37c949f80396c59f2c17e0eda35414979bc07ef3379596a93c9ed044f3a", size = 930768, upload-time = "2025-09-04T18:17:13.349Z" },
 ]
 
 [[package]]
@@ -1197,8 +1196,8 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1" },
-    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db" },
-    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db" },
+    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f" },
+    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
@@ -1216,7 +1215,7 @@ dev = [
 [[package]]
 name = "openhands-sdk"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db#e8f946380e4281ec5b92c21d0f284e322f5a07db" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f#b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f" }
 dependencies = [
     { name = "fastmcp" },
     { name = "litellm" },
@@ -1228,7 +1227,7 @@ dependencies = [
 [[package]]
 name = "openhands-tools"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=e8f946380e4281ec5b92c21d0f284e322f5a07db#e8f946380e4281ec5b92c21d0f284e322f5a07db" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f#b7fd1b7d62f6e857e6d059fe0058f0ecd6f8710f" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },
@@ -1547,7 +1546,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1556,9 +1555,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -1842,28 +1841,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.11"
+version = "0.12.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/55/16ab6a7d88d93001e1ae4c34cbdcfb376652d761799459ff27c1dc20f6fa/ruff-0.12.11.tar.gz", hash = "sha256:c6b09ae8426a65bbee5425b9d0b82796dbb07cb1af045743c79bfb163001165d", size = 5347103, upload-time = "2025-08-28T13:59:08.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f0/e0965dd709b8cabe6356811c0ee8c096806bb57d20b5019eb4e48a117410/ruff-0.12.12.tar.gz", hash = "sha256:b86cd3415dbe31b3b46a71c598f4c4b2f550346d1ccf6326b347cc0c8fd063d6", size = 5359915, upload-time = "2025-09-04T16:50:18.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/a2/3b3573e474de39a7a475f3fbaf36a25600bfeb238e1a90392799163b64a0/ruff-0.12.11-py3-none-linux_armv6l.whl", hash = "sha256:93fce71e1cac3a8bf9200e63a38ac5c078f3b6baebffb74ba5274fb2ab276065", size = 11979885, upload-time = "2025-08-28T13:58:26.654Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e4/235ad6d1785a2012d3ded2350fd9bc5c5af8c6f56820e696b0118dfe7d24/ruff-0.12.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b8e33ac7b28c772440afa80cebb972ffd823621ded90404f29e5ab6d1e2d4b93", size = 12742364, upload-time = "2025-08-28T13:58:30.256Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0d/15b72c5fe6b1e402a543aa9d8960e0a7e19dfb079f5b0b424db48b7febab/ruff-0.12.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d69fb9d4937aa19adb2e9f058bc4fbfe986c2040acb1a4a9747734834eaa0bfd", size = 11920111, upload-time = "2025-08-28T13:58:33.677Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/c0/f66339d7893798ad3e17fa5a1e587d6fd9806f7c1c062b63f8b09dda6702/ruff-0.12.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:411954eca8464595077a93e580e2918d0a01a19317af0a72132283e28ae21bee", size = 12160060, upload-time = "2025-08-28T13:58:35.74Z" },
-    { url = "https://files.pythonhosted.org/packages/03/69/9870368326db26f20c946205fb2d0008988aea552dbaec35fbacbb46efaa/ruff-0.12.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a2c0a2e1a450f387bf2c6237c727dd22191ae8c00e448e0672d624b2bbd7fb0", size = 11799848, upload-time = "2025-08-28T13:58:38.051Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8c/dd2c7f990e9b3a8a55eee09d4e675027d31727ce33cdb29eab32d025bdc9/ruff-0.12.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ca4c3a7f937725fd2413c0e884b5248a19369ab9bdd850b5781348ba283f644", size = 13536288, upload-time = "2025-08-28T13:58:40.046Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/30/d5496fa09aba59b5e01ea76775a4c8897b13055884f56f1c35a4194c2297/ruff-0.12.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4d1df0098124006f6a66ecf3581a7f7e754c4df7644b2e6704cd7ca80ff95211", size = 14490633, upload-time = "2025-08-28T13:58:42.285Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/2f/81f998180ad53445d403c386549d6946d0748e536d58fce5b5e173511183/ruff-0.12.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a8dd5f230efc99a24ace3b77e3555d3fbc0343aeed3fc84c8d89e75ab2ff793", size = 13888430, upload-time = "2025-08-28T13:58:44.641Z" },
-    { url = "https://files.pythonhosted.org/packages/87/71/23a0d1d5892a377478c61dbbcffe82a3476b050f38b5162171942a029ef3/ruff-0.12.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dc75533039d0ed04cd33fb8ca9ac9620b99672fe7ff1533b6402206901c34ee", size = 12913133, upload-time = "2025-08-28T13:58:47.039Z" },
-    { url = "https://files.pythonhosted.org/packages/80/22/3c6cef96627f89b344c933781ed38329bfb87737aa438f15da95907cbfd5/ruff-0.12.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fc58f9266d62c6eccc75261a665f26b4ef64840887fc6cbc552ce5b29f96cc8", size = 13169082, upload-time = "2025-08-28T13:58:49.157Z" },
-    { url = "https://files.pythonhosted.org/packages/05/b5/68b3ff96160d8b49e8dd10785ff3186be18fd650d356036a3770386e6c7f/ruff-0.12.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a0113bd6eafd545146440225fe60b4e9489f59eb5f5f107acd715ba5f0b3d2f", size = 13139490, upload-time = "2025-08-28T13:58:51.593Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b9/050a3278ecd558f74f7ee016fbdf10591d50119df8d5f5da45a22c6afafc/ruff-0.12.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0d737b4059d66295c3ea5720e6efc152623bb83fde5444209b69cd33a53e2000", size = 11958928, upload-time = "2025-08-28T13:58:53.943Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bc/93be37347db854806904a43b0493af8d6873472dfb4b4b8cbb27786eb651/ruff-0.12.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:916fc5defee32dbc1fc1650b576a8fed68f5e8256e2180d4d9855aea43d6aab2", size = 11764513, upload-time = "2025-08-28T13:58:55.976Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a1/1471751e2015a81fd8e166cd311456c11df74c7e8769d4aabfbc7584c7ac/ruff-0.12.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c984f07d7adb42d3ded5be894fb4007f30f82c87559438b4879fe7aa08c62b39", size = 12745154, upload-time = "2025-08-28T13:58:58.16Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/2542b14890d0f4872dd81b7b2a6aed3ac1786fae1ce9b17e11e6df9e31e3/ruff-0.12.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e07fbb89f2e9249f219d88331c833860489b49cdf4b032b8e4432e9b13e8a4b9", size = 13227653, upload-time = "2025-08-28T13:59:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/2fbfc61047dbfd009c58a28369a693a1484ad15441723be1cd7fe69bb679/ruff-0.12.11-py3-none-win32.whl", hash = "sha256:c792e8f597c9c756e9bcd4d87cf407a00b60af77078c96f7b6366ea2ce9ba9d3", size = 11944270, upload-time = "2025-08-28T13:59:02.347Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a5/34276984705bfe069cd383101c45077ee029c3fe3b28225bf67aa35f0647/ruff-0.12.11-py3-none-win_amd64.whl", hash = "sha256:a3283325960307915b6deb3576b96919ee89432ebd9c48771ca12ee8afe4a0fd", size = 13046600, upload-time = "2025-08-28T13:59:04.751Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a8/001d4a7c2b37623a3fd7463208267fb906df40ff31db496157549cfd6e72/ruff-0.12.11-py3-none-win_arm64.whl", hash = "sha256:bae4d6e6a2676f8fb0f98b74594a048bae1b944aab17e9f5d504062303c6dbea", size = 12135290, upload-time = "2025-08-28T13:59:06.933Z" },
+    { url = "https://files.pythonhosted.org/packages/09/79/8d3d687224d88367b51c7974cec1040c4b015772bfbeffac95face14c04a/ruff-0.12.12-py3-none-linux_armv6l.whl", hash = "sha256:de1c4b916d98ab289818e55ce481e2cacfaad7710b01d1f990c497edf217dafc", size = 12116602, upload-time = "2025-09-04T16:49:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c3/6e599657fe192462f94861a09aae935b869aea8a1da07f47d6eae471397c/ruff-0.12.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7acd6045e87fac75a0b0cdedacf9ab3e1ad9d929d149785903cff9bb69ad9727", size = 12868393, upload-time = "2025-09-04T16:49:23.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d2/9e3e40d399abc95336b1843f52fc0daaceb672d0e3c9290a28ff1a96f79d/ruff-0.12.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:abf4073688d7d6da16611f2f126be86523a8ec4343d15d276c614bda8ec44edb", size = 12036967, upload-time = "2025-09-04T16:49:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/03/6816b2ed08836be272e87107d905f0908be5b4a40c14bfc91043e76631b8/ruff-0.12.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:968e77094b1d7a576992ac078557d1439df678a34c6fe02fd979f973af167577", size = 12276038, upload-time = "2025-09-04T16:49:29.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d5/707b92a61310edf358a389477eabd8af68f375c0ef858194be97ca5b6069/ruff-0.12.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42a67d16e5b1ffc6d21c5f67851e0e769517fb57a8ebad1d0781b30888aa704e", size = 11901110, upload-time = "2025-09-04T16:49:32.07Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3d/f8b1038f4b9822e26ec3d5b49cf2bc313e3c1564cceb4c1a42820bf74853/ruff-0.12.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b216ec0a0674e4b1214dcc998a5088e54eaf39417327b19ffefba1c4a1e4971e", size = 13668352, upload-time = "2025-09-04T16:49:35.148Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0e/91421368ae6c4f3765dd41a150f760c5f725516028a6be30e58255e3c668/ruff-0.12.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:59f909c0fdd8f1dcdbfed0b9569b8bf428cf144bec87d9de298dcd4723f5bee8", size = 14638365, upload-time = "2025-09-04T16:49:38.892Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/88f3f06a142f58ecc8ecb0c2fe0b82343e2a2b04dcd098809f717cf74b6c/ruff-0.12.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ac93d87047e765336f0c18eacad51dad0c1c33c9df7484c40f98e1d773876f5", size = 14060812, upload-time = "2025-09-04T16:49:42.732Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fc/8962e7ddd2e81863d5c92400820f650b86f97ff919c59836fbc4c1a6d84c/ruff-0.12.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01543c137fd3650d322922e8b14cc133b8ea734617c4891c5a9fccf4bfc9aa92", size = 13050208, upload-time = "2025-09-04T16:49:46.434Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/8deb52d48a9a624fd37390555d9589e719eac568c020b27e96eed671f25f/ruff-0.12.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afc2fa864197634e549d87fb1e7b6feb01df0a80fd510d6489e1ce8c0b1cc45", size = 13311444, upload-time = "2025-09-04T16:49:49.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/de5a29af7eb8f341f8140867ffb93f82e4fde7256dadee79016ac87c2716/ruff-0.12.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0c0945246f5ad776cb8925e36af2438e66188d2b57d9cf2eed2c382c58b371e5", size = 13279474, upload-time = "2025-09-04T16:49:53.465Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/d9577fdeaf791737ada1b4f5c6b59c21c3326f3f683229096cccd7674e0c/ruff-0.12.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0fbafe8c58e37aae28b84a80ba1817f2ea552e9450156018a478bf1fa80f4e4", size = 12070204, upload-time = "2025-09-04T16:49:56.882Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/a910078284b47fad54506dc0af13839c418ff704e341c176f64e1127e461/ruff-0.12.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b9c456fb2fc8e1282affa932c9e40f5ec31ec9cbb66751a316bd131273b57c23", size = 11880347, upload-time = "2025-09-04T16:49:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/30185fcb0e89f05e7ea82e5817b47798f7fa7179863f9d9ba6fd4fe1b098/ruff-0.12.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f12856123b0ad0147d90b3961f5c90e7427f9acd4b40050705499c98983f489", size = 12891844, upload-time = "2025-09-04T16:50:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/28a8dacce4855e6703dcb8cdf6c1705d0b23dd01d60150786cd55aa93b16/ruff-0.12.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:26a1b5a2bf7dd2c47e3b46d077cd9c0fc3b93e6c6cc9ed750bd312ae9dc302ee", size = 13360687, upload-time = "2025-09-04T16:50:05.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fa/05b6428a008e60f79546c943e54068316f32ec8ab5c4f73e4563934fbdc7/ruff-0.12.12-py3-none-win32.whl", hash = "sha256:173be2bfc142af07a01e3a759aba6f7791aa47acf3604f610b1c36db888df7b1", size = 12052870, upload-time = "2025-09-04T16:50:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/85/60/d1e335417804df452589271818749d061b22772b87efda88354cf35cdb7a/ruff-0.12.12-py3-none-win_amd64.whl", hash = "sha256:e99620bf01884e5f38611934c09dd194eb665b0109104acae3ba6102b600fd0d", size = 13178016, upload-time = "2025-09-04T16:50:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7e/61c42657f6e4614a4258f1c3b0c5b93adc4d1f8575f5229d1906b483099b/ruff-0.12.12-py3-none-win_arm64.whl", hash = "sha256:2a8199cab4ce4d72d158319b63370abf60991495fb733db96cd923a34c52d093", size = 12256762, upload-time = "2025-09-04T16:50:15.737Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR implements confirmation mode in the OpenHands CLI, allowing users to explicitly approve agent actions before they are executed. This addresses issue #15.

## Changes Made

### 1. Updated agent-sdk dependency
- Updated agent-sdk to SHA `e8f946380e4281ec5b92c21d0f284e322f5a07db` to include confirmation mode support
- Updated both hatch and poetry configurations in `pyproject.toml`
- Regenerated `uv.lock` file

### 2. Implemented confirmation mode functionality
- **Environment variable support**: Added support for `CONFIRMATION_MODE=true` or `CONFIRMATION_MODE=1` to enable confirmation mode on startup
- **User confirmation prompts**: Implemented `ask_user_confirmation()` function that displays pending actions and prompts user for approval
- **Action approval/rejection**: Users can respond with "yes"/"y" to approve or "no"/"n" to reject actions
- **Error handling**: Graceful handling of KeyboardInterrupt and EOFError during confirmation prompts

### 3. Added CLI commands
- **`/confirm` command**: Toggle confirmation mode on/off during chat sessions
- **Enhanced `/status` command**: Now displays current confirmation mode status
- **Updated help system**: Added `/confirm` command to the help documentation and command completion

### 4. Enhanced chat loop
- Modified the main chat loop to handle `waiting_for_confirmation` state
- Integrated with agent-sdk's confirmation mode APIs (`get_pending_actions()`, `reject_pending_actions()`)
- Proper state management for confirmation workflow

### 5. Comprehensive testing
- Added `tests/test_confirmation_mode.py` with 13 test cases covering:
  - Environment variable parsing (true/1/false/not set)
  - User confirmation prompts (yes/no/y/n responses)
  - Error handling (KeyboardInterrupt, EOFError)
  - Invalid input handling
  - Multiple actions display
- Updated existing tests to include new `/confirm` command

## Usage

### Enable confirmation mode via environment variable:
```bash
CONFIRMATION_MODE=true openhands-cli
# or
CONFIRMATION_MODE=1 openhands-cli
```

### Toggle confirmation mode during chat:
```
> /confirm
Confirmation mode enabled

> /status
Session ID: chat
Status: Active
Confirmation mode: enabled

> /confirm
Confirmation mode disabled
```

### Confirmation prompt example:
```
🔍 Agent created 2 action(s) and is waiting for confirmation:
  1. bash: ls -la
  2. str_replace_editor: create file.txt with content...

Do you want to execute these actions? (yes/no): yes
✅ Approved — executing actions…
```

## Testing

All tests pass:
- 13 new tests for confirmation mode functionality
- All existing tests continue to pass
- Linting and formatting checks pass

## Fixes

Closes #15

## Notes

This implementation follows the same confirmation mode patterns used in the main OpenHands repository, ensuring consistency across the ecosystem. The feature is backward compatible - existing users will see no change in behavior unless they explicitly enable confirmation mode.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/708ada30888645acaf7d72e0f47b207a)