### PR TITLE
Update agent-sdk SHA and remove openhands/code from Python path

### DIFF
--- a/openhands-cli.spec
+++ b/openhands-cli.spec
@@ -15,14 +15,7 @@ from PyInstaller.utils.hooks import (
     copy_metadata
 )
 
-# Ensure build-time import resolution prefers the packaged SDK over the monorepo path
-# Needed when running build inside OpenHands conversation (due to nested runtimes)
-_sys_paths_to_remove = [p for p in list(sys.path) if p.startswith('/openhands/code')]
-for _p in _sys_paths_to_remove:
-    try:
-        sys.path.remove(_p)
-    except ValueError:
-        pass
+
 
 # Get the project root directory (current working directory when running PyInstaller)
 project_root = Path.cwd()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@6b3b5779d019c8915f5bf228a839b94aa1b26696#subdirectory=openhands/sdk",
-  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@6b3b5779d019c8915f5bf228a839b94aa1b26696#subdirectory=openhands/tools",
+  "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@585d4779b188694e99127431db51190db19e4352#subdirectory=openhands/sdk",
+  "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@585d4779b188694e99127431db51190db19e4352#subdirectory=openhands/tools",
   "prompt-toolkit>=3",
   "typer>=0.17.4",
 ]
@@ -53,8 +53,8 @@ packages = [ { include = "openhands_cli" } ]
 [tool.poetry.dependencies]
 python = "^3.12"
 prompt-toolkit = "^3.0.0"
-openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "6b3b5779d019c8915f5bf228a839b94aa1b26696", subdirectory = "openhands/sdk" }
-openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "6b3b5779d019c8915f5bf228a839b94aa1b26696", subdirectory = "openhands/tools" }
+openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "585d4779b188694e99127431db51190db19e4352", subdirectory = "openhands/sdk" }
+openhands-tools = { git = "https://github.com/All-Hands-AI/agent-sdk.git", rev = "585d4779b188694e99127431db51190db19e4352", subdirectory = "openhands/tools" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
@@ -115,4 +115,4 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 
 [tool.uv.sources]
-openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", subdirectory = "openhands/sdk", rev = "6b3b5779d019c8915f5bf228a839b94aa1b26696" }
+openhands-sdk = { git = "https://github.com/All-Hands-AI/agent-sdk.git", subdirectory = "openhands/sdk", rev = "585d4779b188694e99127431db51190db19e4352" }

--- a/uv.lock
+++ b/uv.lock
@@ -1197,8 +1197,8 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1" },
-    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=6b3b5779d019c8915f5bf228a839b94aa1b26696" },
-    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=6b3b5779d019c8915f5bf228a839b94aa1b26696" },
+    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=585d4779b188694e99127431db51190db19e4352" },
+    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=585d4779b188694e99127431db51190db19e4352" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
@@ -1217,7 +1217,7 @@ dev = [
 [[package]]
 name = "openhands-sdk"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=6b3b5779d019c8915f5bf228a839b94aa1b26696#6b3b5779d019c8915f5bf228a839b94aa1b26696" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk&rev=585d4779b188694e99127431db51190db19e4352#585d4779b188694e99127431db51190db19e4352" }
 dependencies = [
     { name = "fastmcp" },
     { name = "litellm" },
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "openhands-tools"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=6b3b5779d019c8915f5bf228a839b94aa1b26696#6b3b5779d019c8915f5bf228a839b94aa1b26696" }
+source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools&rev=585d4779b188694e99127431db51190db19e4352#585d4779b188694e99127431db51190db19e4352" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },


### PR DESCRIPTION
## Summary

This PR updates the agent-sdk dependency to the latest version and removes unnecessary Python path manipulation code.

## Changes Made

### 1. Updated agent-sdk SHA
- **From**: `6b3b5779d019c8915f5bf228a839b94aa1b26696`
- **To**: `585d4779b188694e99127431db51190db19e4352` (latest from main branch)

Updated in all relevant locations within `pyproject.toml`:
- Main dependencies section (`openhands-sdk` and `openhands-tools`)
- Poetry dependencies section
- UV sources configuration

### 2. Removed Python path manipulation
- Removed code from `openhands-cli.spec` that filtered out `/openhands/code` paths from `sys.path`
- This code was originally added to handle build-time import resolution in nested runtime environments but is no longer needed

### 3. Updated lock file
- Ran `uv sync` to update `uv.lock` with the new SHA references
- All dependency references now point to the latest agent-sdk version

## Testing

The changes have been validated by:
- Successfully running `uv sync` to update dependencies
- Verifying all SHA references have been updated consistently
- Confirming no old SHA references remain in the codebase

## Files Changed

- `pyproject.toml`: Updated agent-sdk SHA in 5 locations
- `openhands-cli.spec`: Removed Python path manipulation code
- `uv.lock`: Updated with new dependency references (auto-generated)

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86efefd584c14c8fb08cb6be0d5561e2)