### PR TITLE
Fix: Check for openhands/ prefix instead of litellm_proxy in model name

### DIFF
--- a/openhands_cli/utils.py
+++ b/openhands_cli/utils.py
@@ -11,8 +11,11 @@ def should_set_litellm_extra_body(model_name: str) -> bool:
     """
     Determine if litellm_extra_body should be set based on the model name.
 
-    Only set litellm_extra_body for litellm_proxy models to avoid issues
+    Only set litellm_extra_body for openhands models to avoid issues
     with providers that don't support extra_body parameters.
+
+    The SDK internally translates "openhands/" prefix to "litellm_proxy/"
+    when making API calls.
 
     Args:
         model_name: Name of the LLM model
@@ -20,7 +23,7 @@ def should_set_litellm_extra_body(model_name: str) -> bool:
     Returns:
         True if litellm_extra_body should be set, False otherwise
     """
-    return "litellm_proxy" in model_name
+    return "openhands/" in model_name
 
 
 def get_llm_metadata(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,18 +3,19 @@
 from openhands_cli.utils import should_set_litellm_extra_body
 
 
-def test_should_set_litellm_extra_body_for_litellm_proxy():
-    """Test that litellm_extra_body is set for litellm_proxy models."""
-    assert should_set_litellm_extra_body("litellm_proxy/gpt-4")
-    assert should_set_litellm_extra_body("litellm_proxy/claude-3")
-    assert should_set_litellm_extra_body("some-provider/litellm_proxy-model")
+def test_should_set_litellm_extra_body_for_openhands():
+    """Test that litellm_extra_body is set for openhands models."""
+    assert should_set_litellm_extra_body("openhands/claude-sonnet-4-5-20250929")
+    assert should_set_litellm_extra_body("openhands/gpt-5-2025-08-07")
+    assert should_set_litellm_extra_body("openhands/devstral-small-2507")
 
 
 def test_should_not_set_litellm_extra_body_for_other_models():
-    """Test that litellm_extra_body is not set for non-litellm_proxy models."""
+    """Test that litellm_extra_body is not set for non-openhands models."""
     assert not should_set_litellm_extra_body("gpt-4")
     assert not should_set_litellm_extra_body("anthropic/claude-3")
     assert not should_set_litellm_extra_body("openai/gpt-4")
     assert not should_set_litellm_extra_body("cerebras/llama3.1-8b")
     assert not should_set_litellm_extra_body("vllm/model")
     assert not should_set_litellm_extra_body("dummy-model")
+    assert not should_set_litellm_extra_body("litellm_proxy/gpt-4")


### PR DESCRIPTION
## Problem
The previous PR (#56) introduced a check for `litellm_proxy` in the model name to determine if `litellm_extra_body` should be set. However, this check is incorrect for the CLI level.

As pointed out by @enyst in https://github.com/OpenHands/OpenHands-CLI/pull/56#discussion_r1858373992, in the CLI, users choose models with the `openhands/` prefix, and the SDK internally translates that to `litellm_proxy/` when making API calls.

This means the check at the CLI level should look for `openhands/` in the model name, not `litellm_proxy`.

## Solution
This PR updates the `should_set_litellm_extra_body()` function to check for `"openhands/"` in the model name instead of `"litellm_proxy"`.

## Changes
- Updated `should_set_litellm_extra_body()` in `openhands_cli/utils.py` to check for `"openhands/"` prefix
- Updated function docstring to explain the SDK translation behavior
- Updated all test cases in `tests/test_utils.py` to use `openhands/` model names
- Added test case to verify `litellm_proxy/` models don't trigger the check (since they wouldn't be seen at CLI level)

## Testing
- All 145 tests pass
- All pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)

## Related
- Supersedes the changes needed after #56 was merged
- Related to https://github.com/OpenHands/software-agent-sdk/pull/1153

cc @enyst @neubig @simonrosenberg @li-boxuan

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/215682e9d3ef424dabf2c92439269f54)