### PR TITLE
Remove continuation prompt '...' from multiline input

### DIFF
--- a/openhands_cli/user_actions/utils.py
+++ b/openhands_cli/user_actions/utils.py
@@ -175,7 +175,6 @@ def get_session_prompter(
     session = PromptSession(
         completer=CommandCompleter(),
         key_bindings=bindings,
-        prompt_continuation=lambda width, line_number, is_soft_wrap: "...",  # noqa: ARG005
         multiline=True,
         input=input,
         output=output,

--- a/tests/test_session_prompter.py
+++ b/tests/test_session_prompter.py
@@ -98,8 +98,3 @@ def test_get_session_prompter_default_parameters():
     assert session.multiline is True
     assert session.key_bindings is not None
     assert session.completer is not None
-
-    # Prompt continuation should be callable and return the expected string
-    cont = session.prompt_continuation
-    assert callable(cont)
-    assert cont(80, 1, False) == "..."


### PR DESCRIPTION
This PR removes the continuation prompt '...' that appeared when sentences spanned multiple lines in the CLI terminal UI.

## Changes
- Remove `prompt_continuation` parameter from PromptSession configuration in `openhands_cli/user_actions/utils.py`
- Update test in `tests/test_session_prompter.py` to remove assertion for continuation prompt

## Impact
- Eliminates the '...' visual indicator that appeared on continuation lines
- Multiline input functionality remains intact
- All existing tests pass

This provides a cleaner multiline input experience without the continuation prompt distraction.