### PR TITLE
feat: Add --version/-v flag support to print CLI version

### DIFF
--- a/openhands_cli/argparsers/main_parser.py
+++ b/openhands_cli/argparsers/main_parser.py
@@ -2,6 +2,8 @@
 
 import argparse
 
+from openhands_cli import __version__
+
 
 def create_main_parser() -> argparse.ArgumentParser:
     """Create the main argument parser with CLI as default and serve as subcommand.
@@ -22,6 +24,15 @@ Examples:
   openhands serve                     # Launch GUI server
   openhands serve --gpu               # Launch GUI server with GPU support
 """,
+    )
+
+    # Version argument
+    parser.add_argument(
+        "--version",
+        "-v",
+        action="version",
+        version=f"OpenHands CLI {__version__}",
+        help="Show the version number and exit",
     )
 
     # CLI arguments at top level (default mode)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -153,3 +153,29 @@ def test_help_and_invalid(monkeypatch, argv, expected_exit_code):
     with pytest.raises(SystemExit) as exc:
         main()
     assert exc.value.code == expected_exit_code
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        (["openhands", "--version"]),
+        (["openhands", "-v"]),
+    ],
+)
+def test_version_flag(monkeypatch, capsys, argv):
+    """Test that --version and -v flags print version and exit."""
+    monkeypatch.setattr(sys, "argv", argv, raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    # Version flag should exit with code 0
+    assert exc.value.code == 0
+
+    # Check that version string is in the output
+    captured = capsys.readouterr()
+    assert "OpenHands CLI" in captured.out
+    # Should contain a version number (matches format like 1.2.1 or 0.0.0)
+    import re
+
+    assert re.search(r"\d+\.\d+\.\d+", captured.out)

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "openhands"
-version = "1.0.6"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "openhands-sdk" },


### PR DESCRIPTION
## Summary
This PR implements support for `--version` and `-v` flags in the OpenHands CLI to display the current version number.

## Changes
- Added `__version__` import to `openhands_cli/argparsers/main_parser.py`
- Implemented `--version/-v` argument with argparse's `version` action
- Added comprehensive tests in `tests/test_main.py` for both flag variants
- Tests validate that:
  - Both `--version` and `-v` flags work correctly
  - Exit code is 0 (success)
  - Output contains "OpenHands CLI" and a semantic version number (X.Y.Z format)

## Testing
All tests pass, including:
- ✅ New version flag tests (2 parametrized tests)
- ✅ All existing tests (17 tests total)
- ✅ Linting checks (ruff format, ruff lint, pycodestyle, pyright)

## Example Output
```bash
$ openhands --version
OpenHands CLI 1.2.1

$ openhands -v
OpenHands CLI 1.2.1
```

Fixes #112

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7966efc6c75845d8bd3cd1f032c2d7cf)