### PR TITLE
docs: improve uv install instructions and dependency comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@ A **lightweight, modern CLI** to interact with the OpenHands agent (powered by [
 ## Quickstart
 
 - Prerequisites: Python 3.12+, curl
-- Install uv (package manager):
+ - Install uv (package manager):
+  
+   **macOS / Linux (bash):**
   ```bash
   curl -LsSf https://astral.sh/uv/install.sh | sh
   # Restart your shell so "uv" is on PATH, or follow the installer hint
+  ```
+
+   **Windows (PowerShell):**
+  ```powershell
+  irm https://astral.sh/uv/install.ps1 | iex
+  # Restart your terminal so "uv" is on PATH, or follow the installer hint
   ```
 
 ### Run the CLI locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-# Using Git URLs for dependencies so installs from PyPI pull from GitHub
-# TODO: pin package versions once agent-sdk has published PyPI packages
+# Using pinned PyPI dependencies for the agent SDK and tools
 dependencies = [
   "openhands-sdk==1.2",
   "openhands-tools==1.2",


### PR DESCRIPTION
**Summary**
- Add Windows (PowerShell) installation instructions for the `uv` package manager in the README Quickstart section.
- Update the [pyproject.toml](cci:7://file:///c:/Users/brass/OneDrive/Desktop/lang/OpenHands-CLI/pyproject.toml:0:0-0:0) comment above `dependencies` to reflect that we now use pinned PyPI packages (`openhands-sdk==1.2`, `openhands-tools==1.2`) instead of Git URLs.

**Motivation**
- On Windows, following the current Quickstart instructions to install `uv` fails because the snippet only shows a Unix `curl | sh` command.
- Adding the official Windows PowerShell installation command makes the Quickstart more accurate and lowers friction for new Windows users.
- The comment in [pyproject.toml](cci:7://file:///c:/Users/brass/OneDrive/Desktop/lang/OpenHands-CLI/pyproject.toml:0:0-0:0) still referred to Git URL dependencies, which is no longer accurate given the pinned PyPI versions.

**Notes**
- On Windows, some tests currently error during collection due to `fcntl` usage in `openhands-tools` (outside this repo). This PR only updates documentation and does not change runtime behavior.