### PR TITLE
Remove -cli suffix requirement from release workflows

### DIFF
--- a/.github/workflows/cli-build-binary-and-optionally-release.yml
+++ b/.github/workflows/cli-build-binary-and-optionally-release.yml
@@ -7,7 +7,7 @@ on:
     push:
         branches: [main]
         tags:
-            - '*-cli'
+            - '*'
     pull_request:
         branches: ['**']
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -22,10 +22,10 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404
         permissions:
             id-token: write
-    # Run when manually dispatched for "cli" OR for tag pushes that contain '-cli'
+    # Run when manually dispatched for "cli" OR for any tag pushes
         if: |
             (github.event_name == 'workflow_dispatch' && github.event.inputs.reason == 'cli')
-            || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-cli'))
+            || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

This PR removes the requirement for tags to end with `-cli` suffix in the GitHub CI release workflows, allowing standard semantic versioning tags to trigger releases.

## Changes Made

### 1. **cli-build-binary-and-optionally-release.yml**
- Changed tag trigger from `*-cli` to `*` (any tag)
- This allows the binary build and GitHub release creation to work with standard tags

### 2. **pypi-release.yml**
- Removed the `contains(github.ref, '-cli')` condition from the workflow trigger
- Updated comment to reflect the change
- This allows PyPI package publication to work with any tag

## Impact

- ✅ Standard semantic versioning tags (e.g., `v1.0.0`, `1.2.3`) will now trigger releases
- ✅ No breaking changes to existing functionality
- ✅ Manual workflow dispatch still works as before
- ✅ All existing release processes remain intact

## Testing

- [x] YAML syntax validation passed for both modified files
- [x] No other files in the repository reference the `-cli` suffix requirement
- [x] Changes are minimal and focused

## Motivation

The previous requirement for `-cli` suffix in tags was unnecessarily restrictive and prevented the use of standard semantic versioning practices. This change simplifies the release process while maintaining all existing functionality.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8f32a3e7894045eabbf6fd3fd56e4050)