### PR TITLE
Display version number in grey color for consistency

### DIFF
--- a/openhands_cli/tui/tui.py
+++ b/openhands_cli/tui/tui.py
@@ -97,9 +97,7 @@ def display_welcome(conversation_id: UUID, resume: bool = False) -> None:
 
     # Check for updates and display version info
     version_info = check_for_updates()
-    print_formatted_text(
-        HTML(f"<grey>Version:</grey> <white>{version_info.current_version}</white>")
-    )
+    print_formatted_text(HTML(f"<grey>Version: {version_info.current_version}</grey>"))
 
     if version_info.needs_update and version_info.latest_version:
         print_formatted_text(


### PR DESCRIPTION
Changed the version display in the welcome screen to use grey color for the entire 'Version: X.Y.Z' text, matching other informational text elements in the TUI. Previously, the version number was displayed in white while the label was in grey.