### PR TITLE
fix: hardcode base_url for OpenHands provider in CLI

### DIFF
--- a/openhands_cli/tui/settings/settings_screen.py
+++ b/openhands_cli/tui/settings/settings_screen.py
@@ -191,6 +191,11 @@ class SettingsScreen:
             extra_kwargs["litellm_extra_body"] = {
                 "metadata": get_llm_metadata(model_name=model, llm_type="agent")
             }
+
+        # Hardcode base_url for OpenHands provider models
+        if model.startswith("openhands/") and base_url is None:
+            base_url = "https://llm-proxy.app.all-hands.dev/"
+
         llm = LLM(
             model=model,
             api_key=api_key,


### PR DESCRIPTION
## Problem

This PR addresses a breaking change introduced by agent-sdk PR #1273 (https://github.com/OpenHands/agent-sdk/pull/1273), which made the `base_url` configurable for the OpenHands provider.

Previously, the agent-sdk hardcoded the `base_url` to `https://llm-proxy.app.all-hands.dev/` when the model started with `openhands/`. After the change, the SDK now respects any `base_url` passed in, defaulting to the proxy URL only if no value is provided.

The OpenHands-CLI wasn't passing a `base_url` when creating LLM configurations, which could cause connection issues when users select the OpenHands provider.

## Solution

This PR updates the CLI to explicitly set `base_url` to `https://llm-proxy.app.all-hands.dev/` when users select the OpenHands provider (models starting with `openhands/`).

### Changes

1. **Updated `_save_llm_settings` method** in `openhands_cli/tui/settings/settings_screen.py`:
   - Automatically sets `base_url` to `https://llm-proxy.app.all-hands.dev/` for OpenHands provider models
   - Only applies the hardcoded value when `base_url` is not explicitly provided
   - Respects any explicitly provided `base_url` value (for advanced use cases)

2. **Added comprehensive tests** in `tests/settings/test_settings_workflow.py`:
   - Test that OpenHands provider models automatically get the correct base_url
   - Test that explicit base_url values are respected even for OpenHands models
   - Test that non-OpenHands providers don't get automatic base_url assignment

## Testing

All tests pass, including the three new test cases:
- `test_openhands_provider_hardcodes_base_url`: Verifies automatic base_url assignment
- `test_openhands_provider_respects_explicit_base_url`: Ensures explicit values are preserved
- `test_non_openhands_provider_no_base_url`: Confirms no side effects for other providers

## Related

- Related to agent-sdk PR #1273: https://github.com/OpenHands/agent-sdk/pull/1273
- Requested by @xingyaoww in https://github.com/OpenHands/agent-sdk/pull/1273#issuecomment

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/hardcode-base-url-for-openhands-provider
```