### PR TITLE
Fix missing import and incorrect parameter names in ACP agent tests

### DIFF
--- a/tests/acp/test_agent.py
+++ b/tests/acp/test_agent.py
@@ -7,6 +7,7 @@ import pytest
 from acp.schema import (
     AgentCapabilities,
     Implementation,
+    NewSessionRequest,
     TextContentBlock,
 )
 
@@ -124,7 +125,7 @@ async def test_new_session_with_malformed_mcp_json(acp_agent, tmp_path, monkeypa
 
     from openhands_cli.tui.settings.store import MCPConfigurationError
 
-    request = NewSessionRequest(cwd=str(tmp_path), mcpServers=[])
+    request = NewSessionRequest(cwd=str(tmp_path), mcp_servers=[])
 
     # Mock load_agent_specs to raise MCPConfigurationError
     with patch("openhands_cli.acp_impl.agent.load_agent_specs") as mock_load:
@@ -134,7 +135,9 @@ async def test_new_session_with_malformed_mcp_json(acp_agent, tmp_path, monkeypa
 
         # Should raise RequestError with helpful message
         with pytest.raises(RequestError) as exc_info:
-            await acp_agent.newSession(request)
+            await acp_agent.new_session(
+                cwd=request.cwd, mcp_servers=request.mcp_servers
+            )
 
         # Verify the error contains helpful information
         error = exc_info.value
@@ -153,7 +156,7 @@ async def test_new_session_with_malformed_mcp_json_integration(
 
     from openhands_cli.tui.settings.store import AgentStore, MCPConfigurationError
 
-    request = NewSessionRequest(cwd=str(tmp_path), mcpServers=[])
+    request = NewSessionRequest(cwd=str(tmp_path), mcp_servers=[])
 
     # Mock AgentStore to inject our own load_mcp_configuration behavior
     original_init = AgentStore.__init__
@@ -180,7 +183,9 @@ async def test_new_session_with_malformed_mcp_json_integration(
 
         # RequestError raised when creating session with malformed mcp.json
         with pytest.raises(RequestError) as exc_info:
-            await acp_agent.newSession(request)
+            await acp_agent.new_session(
+                cwd=request.cwd, mcp_servers=request.mcp_servers
+            )
 
         # Verify the error contains helpful information
         error = exc_info.value


### PR DESCRIPTION
## Description

This PR fixes the failing CI on main that was introduced in commit 740c8ac (PR #153).

## Issues Fixed

The tests added for malformed mcp.json error handling had three bugs:

1. **Missing import**: `NewSessionRequest` was used but not imported from `acp.schema`
2. **Incorrect parameter naming**: Used `mcpServers=[]` (camelCase) instead of `mcp_servers=[]` (Python snake_case convention)
3. **Incorrect method calls**: Called `acp_agent.newSession()` instead of `acp_agent.new_session()` (Python naming convention)

## Changes Made

- Added `NewSessionRequest` to imports from `acp.schema` in `tests/acp/test_agent.py`
- Fixed parameter names from `mcpServers` to `mcp_servers` in two test functions
- Fixed method calls to use `new_session()` with explicit parameters instead of `newSession(request)`

## Verification

✅ All lint checks pass (ruff format, ruff lint, pycodestyle, pyright)  
✅ All 254 tests pass (including the 22 ACP agent tests)

## Related

Fixes the CI failures on main introduced by PR #153 (commit 740c8ac)

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d5ca980d916a4efb890d935e88d6a048)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix-acp-test-failures
```