### PR TITLE
Fix URL display by adding newlines to prevent truncation

### DIFF
--- a/openhands_cli/user_actions/settings_action.py
+++ b/openhands_cli/user_actions/settings_action.py
@@ -72,7 +72,8 @@ def choose_llm_model(step_counter: StepCounter, provider: str, escapable=True) -
     if provider == "openhands":
         question = (
             step_counter.next_step("Select Available OpenHands Model:\n")
-            + "LLM usage is billed at the providers’ rates with no markup. Details: https://docs.all-hands.dev/usage/llms/openhands-llms"
+            + "LLM usage is billed at the providers’ rates with no markup.\n"
+            + "Details: https://docs.all-hands.dev/usage/llms/openhands-llms"
         )
     else:
         question = step_counter.next_step(
@@ -108,7 +109,7 @@ def prompt_api_key(
     )
     helper_text = (
         "\nYou can find your OpenHands LLM API Key in the API Keys tab of "
-        "OpenHands Cloud: "
+        "OpenHands Cloud:\n"
         "https://app.all-hands.dev/settings/api-keys\n"
         if provider == "openhands"
         else ""


### PR DESCRIPTION
## Description

Fixes URL truncation issue where URLs displayed in the CLI were cut off in narrow terminals, as reported in the #p-toad Slack channel.

## Problem

When the OpenHands CLI prompts users for API keys or displays information about OpenHands models, URLs are displayed inline with other text. In narrow terminals or when terminals don't resize properly, these URLs get truncated, making them difficult or impossible to see and copy.

This was particularly problematic during the initial setup flow when users need to retrieve their API key from `https://app.all-hands.dev/settings/api-keys`.

## Solution

Added newlines (`\n`) before URLs to ensure they display on their own lines, making them fully visible regardless of terminal width.

## Changes

1. **Line 75-76**: Added newline before OpenHands LLM pricing details URL
   - Changed from: `"...no markup. Details: https://docs.all-hands.dev/usage/llms/openhands-llms"`
   - Changed to: `"...no markup.\n" + "Details: https://docs.all-hands.dev/usage/llms/openhands-llms"`

2. **Line 112**: Added newline before OpenHands API key settings URL  
   - Changed from: `"OpenHands Cloud: https://app.all-hands.dev/settings/api-keys\n"`
   - Changed to: `"OpenHands Cloud:\nhttps://app.all-hands.dev/settings/api-keys\n"`

## Testing

- ✅ All linters pass:
  - `ruff format` - No formatting changes needed
  - `ruff check --fix` - All checks passed
  - `pycodestyle` - No issues
  - `pyright` - 0 errors, 0 warnings
- ✅ All tests pass: `pytest tests/settings/` - 32 tests passed

## Visual Impact

### Before
```
You can find your OpenHands LLM API Key in the API Keys tab of OpenHands Cloud: https://app.all-hands.dev/settings/api-keys
```
(URL might be truncated depending on terminal width)

### After
```
You can find your OpenHands LLM API Key in the API Keys tab of OpenHands Cloud:
https://app.all-hands.dev/settings/api-keys
```
(URL always visible on its own line)

## Related

Addresses issue reported by @willmcgugan in Slack #p-toad channel regarding truncated URLs during CLI setup that required manual terminal resizing to view.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd686cd0e6094d3ca6b9b0994a2acdc0)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/url-display-newline
```