### PR TITLE
Add metrics to ACP meta field

### DIFF
--- a/openhands_cli/acp_impl/agent.py
+++ b/openhands_cli/acp_impl/agent.py
@@ -199,7 +199,7 @@ class OpenHandsACPAgent(ACPAgent):
         )
 
         # Set conversation reference in subscriber for metrics access
-        subscriber.set_conversation(conversation)
+        subscriber.conversation = conversation
 
         # # Set up security analyzer (same as setup_conversation with confirmation mode)
         # conversation.set_security_analyzer(LLMSecurityAnalyzer())

--- a/openhands_cli/acp_impl/event.py
+++ b/openhands_cli/acp_impl/event.py
@@ -109,23 +109,21 @@ class EventSubscriber:
     them to ACP session update notifications that are streamed back to the client.
     """
 
-    def __init__(self, session_id: str, conn: "AgentSideConnection"):
+    def __init__(
+        self,
+        session_id: str,
+        conn: "AgentSideConnection",
+        conversation: BaseConversation | None = None,
+    ):
         """Initialize the event subscriber.
 
         Args:
             session_id: The ACP session ID
             conn: The ACP connection for sending notifications
+            conversation: Optional conversation instance for accessing metrics
         """
         self.session_id = session_id
         self.conn = conn
-        self.conversation: BaseConversation | None = None
-
-    def set_conversation(self, conversation: "BaseConversation") -> None:
-        """Set the conversation reference for accessing stats.
-
-        Args:
-            conversation: The conversation instance
-        """
         self.conversation = conversation
 
     def _get_metadata(self) -> dict[str, dict[str, int | float]] | None:


### PR DESCRIPTION
## Summary
This PR adds conversation metrics to the ACP `_meta` field in session updates, following the [ACP extensibility spec](https://agentclientprotocol.com/protocol/extensibility#the-meta-field).

## Changes
- Modified `EventSubscriber` to store a reference to the conversation
- Added `_get_metrics_meta()` method that extracts metrics from `conversation.conversation_stats`
- Created helper function `_add_meta_to_update()` to attach `_meta` field to update objects
- Updated all session update handlers to include metrics in the `_meta` field
- Updated `agent.py` to pass the conversation to the event subscriber

## Metrics Included
The `_meta` field now includes:
- `input_tokens`: Total input tokens used
- `output_tokens`: Total output tokens generated
- `cache_read_tokens`: Cache read tokens (if available)
- `reasoning_tokens`: Reasoning tokens used (if available)
- `cost`: Total cost in USD

## Implementation Details
The metrics extraction follows the same pattern as `_format_metrics_subtitle()` in the `software-agent-sdk`, ensuring consistency across the OpenHands ecosystem.

## Testing
- [x] Pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)
- [x] Code follows repository patterns and conventions

## Related Issues
Addresses the request to display conversation metrics through ACP's meta field extensibility.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6dfd8f166c0949129d900f873c4b6a58)


Confirmed it works:

<img width="2196" height="1804" alt="image" src="https://github.com/user-attachments/assets/32afc3e6-b8a1-4b16-8eb4-25b4d2e62e3e" />


---

---


---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@add-metrics-to-meta-field
```