### PR TITLE
Fix MCP visualization error with Linear MCP server returning JSON lists

### DIFF
--- a/openhands_cli/acp_impl/agent.py
+++ b/openhands_cli/acp_impl/agent.py
@@ -48,6 +48,7 @@ from openhands_cli.acp_impl.utils import (
 from openhands_cli.locations import CONVERSATIONS_DIR, MCP_CONFIG_FILE, WORK_DIR
 from openhands_cli.setup import MissingAgentSpec, load_agent_specs
 from openhands_cli.tui.settings.store import MCPConfigurationError
+from openhands_cli.utils import apply_mcp_visualization_fix
 
 
 logger = logging.getLogger(__name__)
@@ -512,6 +513,9 @@ class OpenHandsACPAgent(ACPAgent):
 
 async def run_acp_server() -> None:
     """Run the OpenHands ACP server."""
+    # Apply fix for MCP visualization issue with Linear MCP server
+    apply_mcp_visualization_fix()
+
     logger.info("Starting OpenHands ACP server...")
 
     reader, writer = await stdio_streams()

--- a/openhands_cli/simple_main.py
+++ b/openhands_cli/simple_main.py
@@ -21,7 +21,10 @@ from openhands.sdk.security.confirmation_policy import (
 )
 from openhands.sdk.security.risk import SecurityRisk
 from openhands_cli.argparsers.main_parser import create_main_parser
-from openhands_cli.utils import create_seeded_instructions_from_args
+from openhands_cli.utils import (
+    apply_mcp_visualization_fix,
+    create_seeded_instructions_from_args,
+)
 
 
 env_path = Path.cwd() / ".env"
@@ -42,6 +45,9 @@ def main() -> None:
         ImportError: If agent chat dependencies are missing
         Exception: On other error conditions
     """
+    # Apply fix for MCP visualization issue with Linear MCP server
+    apply_mcp_visualization_fix()
+
     parser = create_main_parser()
     args = parser.parse_args()
 

--- a/tests/test_mcp_visualization_fix.py
+++ b/tests/test_mcp_visualization_fix.py
@@ -1,0 +1,177 @@
+"""Tests for MCP visualization fix.
+
+This module tests the fix for the issue where Linear MCP server returns JSON lists
+causing 'list' object has no attribute 'items' error in the SDK's display_dict function.
+"""
+
+import json
+import pytest
+
+from openhands_cli.utils import apply_mcp_visualization_fix, display_json_data
+
+
+class TestMCPVisualizationFix:
+    """Test cases for the MCP visualization fix."""
+
+    def test_display_json_data_with_dict(self):
+        """Test display_json_data with dictionary input (original working case)."""
+        data = {
+            "id": "123",
+            "title": "Test Issue",
+            "description": "Multi-line\ndescription",
+            "status": "open",
+        }
+        result = display_json_data(data)
+        
+        # Check that all fields are present in the output
+        output = result.plain
+        assert "id:" in output
+        assert "title:" in output
+        assert "description:" in output
+        assert "status:" in output
+        assert '"123"' in output
+        assert '"Test Issue"' in output
+
+    def test_display_json_data_with_list(self):
+        """Test display_json_data with list input (the problematic case)."""
+        data = [
+            {"id": "1", "name": "Item 1"},
+            {"id": "2", "name": "Item 2"},
+            "Simple string",
+            42,
+        ]
+        result = display_json_data(data)
+        
+        # Check that list items are formatted correctly
+        output = result.plain
+        assert "[0]:" in output
+        assert "[1]:" in output
+        assert "[2]:" in output
+        assert "[3]:" in output
+        assert "Simple string" in output
+        assert "42" in output
+
+    def test_display_json_data_with_string(self):
+        """Test display_json_data with string input."""
+        data = "Simple string response"
+        result = display_json_data(data)
+        
+        output = result.plain
+        assert output == "Simple string response"
+
+    def test_display_json_data_with_number(self):
+        """Test display_json_data with number input."""
+        data = 42
+        result = display_json_data(data)
+        
+        output = result.plain
+        assert output == "42"
+
+    def test_display_json_data_with_boolean(self):
+        """Test display_json_data with boolean input."""
+        data = True
+        result = display_json_data(data)
+        
+        output = result.plain
+        assert output == "True"
+
+    def test_display_json_data_with_none(self):
+        """Test display_json_data with None input."""
+        data = None
+        result = display_json_data(data)
+        
+        output = result.plain
+        assert output == "None"
+
+    def test_monkey_patch_application(self):
+        """Test that the monkey patch is applied correctly."""
+        # Apply the fix
+        apply_mcp_visualization_fix()
+        
+        # Import the SDK module
+        import openhands.sdk.utils.visualize
+        
+        # Test with a list (the problematic case)
+        test_list = [{"key": "value"}, "string", 123]
+        
+        # This should not raise an AttributeError
+        result = openhands.sdk.utils.visualize.display_dict(test_list)
+        
+        # Verify the result is correct
+        output = result.plain
+        assert "[0]:" in output
+        assert "[1]:" in output
+        assert "[2]:" in output
+
+    def test_mcp_observation_simulation(self):
+        """Test the full MCP observation scenario that was causing the error."""
+        # Apply the fix first
+        apply_mcp_visualization_fix()
+        
+        # Simulate Linear MCP server response (JSON list)
+        json_response = '''[
+            {
+                "id": "issue-123",
+                "title": "Fix MCP visualization bug",
+                "status": "in_progress"
+            },
+            {
+                "id": "issue-124", 
+                "title": "Update documentation",
+                "status": "open"
+            }
+        ]'''
+        
+        # Parse the JSON (this is what happens in MCPToolObservation.visualize)
+        parsed = json.loads(json_response)
+        
+        # Import the patched function
+        from openhands.sdk.utils.visualize import display_dict
+        
+        # This should work without error
+        result = display_dict(parsed)
+        
+        # Verify the output contains expected content
+        output = result.plain
+        assert "issue-123" in output
+        assert "issue-124" in output
+        assert "Fix MCP visualization bug" in output
+        assert "Update documentation" in output
+
+    def test_nested_data_structures(self):
+        """Test display_json_data with nested data structures."""
+        data = {
+            "issues": [
+                {"id": "1", "title": "First issue"},
+                {"id": "2", "title": "Second issue"},
+            ],
+            "metadata": {
+                "total": 2,
+                "page": 1,
+            },
+        }
+        result = display_json_data(data)
+        
+        output = result.plain
+        assert "issues:" in output
+        assert "metadata:" in output
+        # Nested structures should be converted to string representation
+        assert "First issue" in output or "id" in output
+
+    def test_empty_list(self):
+        """Test display_json_data with empty list."""
+        data = []
+        result = display_json_data(data)
+        
+        # Should handle empty list gracefully
+        output = result.plain
+        assert output.strip() == ""
+
+    def test_empty_dict(self):
+        """Test display_json_data with empty dictionary."""
+        data = {}
+        result = display_json_data(data)
+        
+        # Should handle empty dict gracefully
+        output = result.plain
+        assert output.strip() == ""


### PR DESCRIPTION
## Problem

When using the Linear MCP server with OpenHands-CLI, users encounter the following error:

```
AttributeError: 'list' object has no attribute 'items'
```

This occurs in the SDK's visualization code (`openhands/sdk/utils/visualize.py`) when the Linear MCP server returns JSON responses as lists instead of dictionaries. The `display_dict` function assumes all data is a dictionary and calls `.items()` on it, which fails for lists.

## Root Cause

The error originates from:
1. `openhands/sdk/mcp/definition.py:100` - calls `display_dict(parsed)` 
2. `openhands/sdk/utils/visualize.py:7` - assumes `d.items()` exists, but `d` can be a list

## Solution

This PR implements a comprehensive fix:

### 1. Enhanced JSON Data Display Function
- Added `display_json_data()` function in `openhands_cli/utils.py` that handles:
  - **Dictionaries**: Formats key-value pairs with proper indentation
  - **Lists**: Formats items with indexed labels `[0]:`, `[1]:`, etc.
  - **Other types**: Converts to string representation

### 2. Monkey Patch for SDK Compatibility
- Added `apply_mcp_visualization_fix()` function that patches the SDK's `display_dict` function
- Applied early in both CLI entry points:
  - `openhands_cli/simple_main.py` (main CLI)
  - `openhands_cli/acp_impl/agent.py` (ACP server)

### 3. Comprehensive Testing
- Added `tests/test_mcp_visualization_fix.py` with 11 test cases covering:
  - Dictionary handling (original working case)
  - List handling (the problematic case)
  - String, number, boolean, and None handling
  - Monkey patch verification
  - Full MCP observation simulation
  - Nested data structures and edge cases

## Changes Made

- **Modified**: `openhands_cli/utils.py` - Added visualization fix functions
- **Modified**: `openhands_cli/simple_main.py` - Apply fix at startup
- **Modified**: `openhands_cli/acp_impl/agent.py` - Apply fix at ACP server startup
- **Added**: `tests/test_mcp_visualization_fix.py` - Comprehensive test suite

## Testing

All tests pass:
```bash
pytest tests/test_mcp_visualization_fix.py -v
# 11 passed, 2 warnings in 0.51s
```

The fix has been verified to handle:
- ✅ Linear MCP server JSON list responses
- ✅ Traditional dictionary responses  
- ✅ Mixed data types and nested structures
- ✅ Edge cases (empty lists/dicts, None values)

## Impact

- **Fixes**: The specific error with Linear MCP server
- **Maintains**: Full backward compatibility with existing dictionary responses
- **Improves**: Overall robustness of MCP response visualization
- **No breaking changes**: Uses monkey patching to avoid SDK modifications

This fix resolves the immediate issue while maintaining compatibility and providing a foundation for handling diverse MCP server response formats.

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47c2f4ca1b6c40a29e6880f8a4c033ca)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/mcp-visualization-list-error
```