### PR TITLE
Handle IDLE as terminal in confirmation-mode loop

### DIFF
--- a/openhands_cli/runner.py
+++ b/openhands_cli/runner.py
@@ -110,6 +110,8 @@ class ConversationRunner:
             if (
                 self.conversation.state.execution_status
                 == ConversationExecutionStatus.FINISHED
+                or self.conversation.state.execution_status
+                == ConversationExecutionStatus.IDLE
             ):
                 break
 


### PR DESCRIPTION
Summary

Adjust the CLI runner to work with the updated SDK behavior where content-only assistant replies set execution_status=IDLE and run() breaks.

Change
- In ConversationRunner._run_with_confirmation, break the loop on FINISHED or IDLE (previously only FINISHED), maintaining existing handling of WAITING_FOR_CONFIRMATION and PAUSED.

Dependency
- This change assumes the SDK PR that yields IDLE on content-only messages and breaks run() on IDLE is merged first.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e0ed4e7546a74811952c3d5c4fab4491)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feature/idle-support
```