### PR TITLE
feat: Add versioning for agent_settings.json

### DIFF
--- a/tests/settings/test_agent_settings_version.py
+++ b/tests/settings/test_agent_settings_version.py
@@ -33,8 +33,8 @@ class TestSerializeAgentMinimal:
 
     def test_includes_version_field(self):
         """Test that serialized output includes _version field."""
-        with patch("openhands_cli.stores.agent_store.LLM") as MockLLM:
-            from openhands.sdk import Agent, LLM
+        with patch("openhands_cli.stores.agent_store.LLM"):
+            from openhands.sdk import LLM, Agent
 
             llm = LLM(model="test-model", api_key="test-key")
             agent = Agent(llm=llm)
@@ -47,7 +47,7 @@ class TestSerializeAgentMinimal:
 
     def test_preserves_condenser_kind(self):
         """Test that condenser kind discriminator is preserved."""
-        from openhands.sdk import Agent, LLM, LLMSummarizingCondenser
+        from openhands.sdk import LLM, Agent, LLMSummarizingCondenser
 
         llm = LLM(model="test-model", api_key="test-key")
         condenser = LLMSummarizingCondenser(llm=llm)
@@ -61,7 +61,7 @@ class TestSerializeAgentMinimal:
 
     def test_excludes_default_values(self):
         """Test that default values are excluded from serialization."""
-        from openhands.sdk import Agent, LLM, LLMSummarizingCondenser
+        from openhands.sdk import LLM, Agent, LLMSummarizingCondenser
 
         llm = LLM(model="test-model", api_key="test-key")
         condenser = LLMSummarizingCondenser(llm=llm)
@@ -232,7 +232,7 @@ class TestAgentStoreSave:
 
     def test_save_uses_minimal_serialization(self, agent_store, mock_file_store):
         """Test that save uses _serialize_agent_minimal."""
-        from openhands.sdk import Agent, LLM, LLMSummarizingCondenser
+        from openhands.sdk import LLM, Agent, LLMSummarizingCondenser
 
         llm = LLM(model="test-model", api_key="test-key")
         condenser = LLMSummarizingCondenser(llm=llm)


### PR DESCRIPTION
## Summary

This PR implements versioning for `agent_settings.json` to handle SDK default changes gracefully. When the SDK updates condenser settings (like `max_size`, `keep_first`), users will automatically get the new defaults without needing to reconfigure.

## Changes

### New Features
- **Version field**: Added `_version` field to agent settings (current version: `v1`)
- **Minimal serialization**: Uses `exclude_defaults=True` to only save user-configured values, ensuring users automatically get updated SDK defaults
- **Discriminator preservation**: Preserves the `kind` field for polymorphic types (like condenser) for proper deserialization
- **Auto-migration**: Automatically migrates v0 (legacy) settings to v1 format on load
- **Fresh condenser on load**: Always creates a fresh condenser with current SDK defaults when loading settings

### Implementation Details
- Added `_serialize_agent_minimal()` function that:
  - Uses `exclude_defaults=True` to omit SDK default values
  - Preserves discriminator fields for polymorphic types
  - Adds `_version` field to track settings format version

- Updated `AgentStore.load()` to:
  - Parse JSON and check version before validation
  - Remove `_version` field before validating as Agent model
  - Always create fresh condenser with SDK defaults (not persisted values)
  - Auto-migrate v0 settings to v1 on load

- Updated `AgentStore.save()` to use the new minimal serialization

### Tests
Added comprehensive tests in `tests/settings/test_agent_settings_version.py`:
- Test version field inclusion
- Test condenser kind preservation
- Test default value exclusion
- Test version detection (v0 vs v1)
- Test v0 migration triggers re-save
- Test v1 does not trigger re-save
- Test fresh condenser creation with SDK defaults
- Test save uses minimal serialization

## Related Discussion
This addresses the discussion about transitioning agent settings format to handle SDK condenser default changes (from the conversation about SDK release 1.7.2).

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47467da2d0814d32b051d8ea0c9965a8)

---

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/agent-settings-versioning
```