### PR TITLE
fix: use model_id without provider prefix when loading settings

### DIFF
--- a/openhands_cli/tui/modals/settings/settings_screen.py
+++ b/openhands_cli/tui/modals/settings/settings_screen.py
@@ -174,7 +174,7 @@ class SettingsScreen(ModalScreen):
 
                 # Update model options and select current model
                 self._update_model_options(provider)
-                # Use model (without provider prefix) since dropdown options don't include prefix
+                # Use model without provider prefix (dropdown options don't have it)
                 self.model_select.value = model
 
         # API Key (show masked version)

--- a/tests/refactor/modals/settings/test_settings_screen.py
+++ b/tests/refactor/modals/settings/test_settings_screen.py
@@ -132,7 +132,7 @@ async def test_load_current_settings_basic_mode(
     screen.current_agent = fake_agent_store.load()
 
     with patch.object(ss, "get_model_options") as mock_get_options:
-        # Model options don't include provider prefix (matches real get_model_options behavior)
+        # Model options don't include provider prefix
         mock_get_options.return_value = [
             ("gpt-4o-mini", "gpt-4o-mini"),
             ("gpt-4o", "gpt-4o"),


### PR DESCRIPTION
## Summary

Fixes `InvalidSelectValueError: Illegal select value 'cerebras/zai-glm-4.6'` that occurs when opening the settings screen after configuring a model like `cerebras/zai-glm-4.6`.

## Root Cause

When loading settings in basic mode, the `_load_current_settings()` method was setting `model_select.value` to the full model string (e.g., `cerebras/zai-glm-4.6`), but the dropdown options from `get_model_options()` only contain model IDs without the provider prefix (e.g., `zai-glm-4.6`).

This caused the Textual Select widget to throw `InvalidSelectValueError` because the value being set was not in the list of valid options.

## Fix

Changed line 177 in `settings_screen.py` to use the `model` variable (extracted from splitting `llm.model` by `/`) instead of the full `llm.model` string when setting `model_select.value`.

## Testing

HUMAN: this has been QAed, confirmed to fail before

<img width="498" height="81" alt="Screenshot 2026-01-02 at 9 22 29 AM" src="https://github.com/user-attachments/assets/c041acce-5cbf-4553-be96-d35b41727d9f" />

and work after

<img width="545" height="550" alt="Screenshot 2026-01-02 at 9 23 02 AM" src="https://github.com/user-attachments/assets/3076079a-1068-4294-a115-8623d773fc21" />

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/model-select-invalid-value
```