### PR TITLE
Skip PR description update for forked repos

### DIFF
--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -19,7 +19,7 @@ jobs:
     update-pr-description:
         name: Update PR Description with uvx Instructions
         runs-on: ubuntu-latest
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Summary

This PR fixes the HTTP 403 error that occurs when the `update-pr-description` workflow runs on PRs from forked repositories.

<img width="1698" height="298" alt="image" src="https://github.com/user-attachments/assets/e5ac492a-216d-4a8d-afe4-3e1edaae497c" />


## Problem

When a PR is opened from a forked repository, the workflow fails with:
```
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/pulls/pulls#update-a-pull-request","status":"403"}
```

This happens because GitHub's `GITHUB_TOKEN` has limited (read-only) permissions for PRs from forked repositories as a security measure.

## Solution

Added a condition to skip the PR description update job for forked PRs:
```yaml
if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
```

This approach matches how the main [OpenHands repository](https://github.com/OpenHands/OpenHands) handles the same situation in their `ghcr-build.yml` workflow.

## Behavior After This Change

- **PRs from the same repository**: Continue to have their descriptions updated automatically with uvx instructions
- **PRs from forked repositories**: The job is gracefully skipped instead of failing

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/skip-pr-update-for-forks
```