### PR TITLE
fix(tui): disable markup parsing for user messages to prevent crashes

### DIFF
--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -362,7 +362,9 @@ class OpenHandsApp(App):
         user_input = self.pending_inputs.pop(0)
 
         # Add the user message to the main display as a Static widget
-        user_message_widget = Static(f"> {user_input}", classes="user-message")
+        user_message_widget = Static(
+            f"> {user_input}", classes="user-message", markup=False
+        )
         self.main_display.mount(user_message_widget)
         self.main_display.scroll_end(animate=False)
 
@@ -376,7 +378,9 @@ class OpenHandsApp(App):
             return
 
         # Add the user message to the main display as a Static widget
-        user_message_widget = Static(f"> {content}", classes="user-message")
+        user_message_widget = Static(
+            f"> {content}", classes="user-message", markup=False
+        )
         await self.main_display.mount(user_message_widget)
         self.main_display.scroll_end(animate=False)
         # Force immediate refresh to show the message without delay


### PR DESCRIPTION
Add markup=False to Static widgets displaying user input to prevent Textual from interpreting special characters as markup syntax.

Previously, user messages containing square brackets or other markup-like characters (e.g., '[type=frozen_instance, input_value={}, input_type=dict]') would cause the application to crash as Textual attempted to parse them as markup.

This fix ensures user input is displayed as plain text regardless of content, improving robustness and preventing crashes from unexpected input patterns.

Fixes: Issue where user messages with markup-like syntax cause app crashes