### PR TITLE
Fix AGENTS.md not being loaded when skills directories don't exist

### DIFF
--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -1,6 +1,8 @@
 # openhands_cli/settings/store.py
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any
 
 from prompt_toolkit import HTML, print_formatted_text
@@ -13,6 +15,7 @@ from openhands.sdk import (
     LocalFileStore,
 )
 from openhands.sdk.context import load_project_skills
+from openhands.sdk.context.skills import Skill, load_skills_from_dir
 from openhands.tools.preset.default import get_default_tools
 from openhands_cli.locations import (
     AGENT_SETTINGS_PATH,
@@ -25,6 +28,75 @@ from openhands_cli.utils import (
     get_os_description,
     should_set_litellm_extra_body,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_third_party_skills_from_work_dir(work_dir: str | Path) -> list[Skill]:
+    """Load third-party skill files (AGENTS.md, etc.) directly from work directory.
+
+    This function addresses a bug in the SDK where third-party skill files like
+    AGENTS.md are only loaded if .openhands/skills or .openhands/microagents
+    directories exist. This function ensures these files are loaded regardless
+    of whether those directories exist.
+
+    Uses the SDK's load_skills_from_dir() which already has logic to check for
+    third-party files in the repo root (calculated as skill_dir.parent.parent).
+    By passing the expected skills directory path, even if it doesn't exist,
+    the SDK will still check for third-party files in the work directory.
+
+    Additionally scans the directory for case-insensitive matches since the SDK's
+    variant matching doesn't handle mixed case (e.g., "AGENTS.md").
+
+    Args:
+        work_dir: Path to the working directory (project root).
+
+    Returns:
+        List of Skill objects loaded from third-party files.
+    """
+    if isinstance(work_dir, str):
+        work_dir = Path(work_dir)
+
+    skills = []
+    seen_names: set[str] = set()
+
+    # Use SDK's load_skills_from_dir() which handles third-party files
+    # when the skills directory path is provided (even if it doesn't exist)
+    skills_dir = work_dir / ".openhands" / "skills"
+    try:
+        repo_skills, _ = load_skills_from_dir(skills_dir)
+        for name, skill in repo_skills.items():
+            if name not in seen_names:
+                skills.append(skill)
+                seen_names.add(name)
+    except Exception as e:
+        logger.debug(f"SDK load_skills_from_dir failed: {e}")
+
+    # Scan directory for case-insensitive matches (SDK doesn't handle mixed case)
+    third_party_filenames_lower = {
+        name.lower() for name in Skill.PATH_TO_THIRD_PARTY_SKILL_NAME.keys()
+    }
+
+    try:
+        for file_path in work_dir.iterdir():
+            if not file_path.is_file():
+                continue
+
+            if file_path.name.lower() in third_party_filenames_lower:
+                try:
+                    skill = Skill.load(file_path)
+                    if skill.name not in seen_names:
+                        skills.append(skill)
+                        seen_names.add(skill.name)
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to load third-party skill from {file_path}: {e}"
+                    )
+    except OSError as e:
+        logger.warning(f"Failed to scan work directory {work_dir}: {e}")
+
+    return skills
 
 
 class AgentStore:
@@ -43,6 +115,19 @@ class AgentStore:
 
             # Load skills from user directories and project-specific directories
             skills = load_project_skills(WORK_DIR)
+
+            # Load third-party skill files (AGENTS.md, etc.) directly from work dir
+            # This ensures they are loaded even if .openhands/skills doesn't exist
+            # (workaround for SDK bug where third-party files are only checked
+            # inside load_skills_from_dir which requires skills directory to exist)
+            third_party_skills = load_third_party_skills_from_work_dir(WORK_DIR)
+
+            # Merge third-party skills with project skills, avoiding duplicates
+            existing_skill_names = {s.name for s in skills}
+            for skill in third_party_skills:
+                if skill.name not in existing_skill_names:
+                    skills.append(skill)
+                    existing_skill_names.add(skill.name)
 
             system_suffix = "\n".join(
                 [

--- a/tests/settings/test_skills_loading.py
+++ b/tests/settings/test_skills_loading.py
@@ -51,6 +51,54 @@ This is a test skill for testing purposes.
 
 
 @pytest.fixture
+def temp_project_dir_with_agents_md_only():
+    """Create a temporary project directory with only AGENTS.md (no skills dirs)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create AGENTS.md file in the root directory (no .openhands/skills)
+        agents_md = Path(temp_dir) / "AGENTS.md"
+        agents_md.write_text("""# Project Guidelines
+
+This is the AGENTS.md file with project-specific instructions.
+
+## Code Style
+- Use consistent formatting
+- Write clear comments
+
+## Testing
+- Always write tests for new features
+""")
+
+        yield temp_dir
+
+
+@pytest.fixture
+def temp_project_dir_with_agents_md_and_skills():
+    """Create a temporary project directory with both AGENTS.md and skills dirs."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create AGENTS.md file in the root directory
+        agents_md = Path(temp_dir) / "AGENTS.md"
+        agents_md.write_text("""# Project Guidelines
+
+This is the AGENTS.md file with project-specific instructions.
+""")
+
+        # Also create skills directory with a skill
+        skills_dir = Path(temp_dir) / ".openhands" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        skill_file = skills_dir / "test_skill.md"
+        skill_file.write_text("""---
+name: test_skill
+triggers: ["test", "skill"]
+---
+
+This is a test skill for testing purposes.
+""")
+
+        yield temp_dir
+
+
+@pytest.fixture
 def agent_store(temp_project_dir):
     """Create an AgentStore with the temporary project directory."""
     with patch("openhands_cli.stores.agent_store.WORK_DIR", temp_project_dir):
@@ -217,3 +265,155 @@ This is a user microagent for testing.
 
             # Should have project skills + mocked public skill
             assert "github" in skill_names  # mocked public skill
+
+
+class TestThirdPartySkillsLoading:
+    """Test loading of third-party skill files (AGENTS.md, etc.)."""
+
+    def test_load_agents_md_without_skills_directory(
+        self, temp_project_dir_with_agents_md_only
+    ):
+        """Test that AGENTS.md is loaded even when .openhands/skills doesn't exist.
+
+        This is the main bug fix test - verifies that third-party skill files
+        like AGENTS.md are loaded from the work directory even when the
+        .openhands/skills directory doesn't exist.
+        """
+        from openhands.sdk import LLM, Agent
+
+        with patch(
+            "openhands_cli.stores.agent_store.WORK_DIR",
+            temp_project_dir_with_agents_md_only,
+        ):
+            from openhands_cli.stores import AgentStore
+
+            agent_store = AgentStore()
+
+            # Create a test agent to save first
+            test_agent = Agent(llm=LLM(model="gpt-4o-mini"))
+            agent_store.save(test_agent)
+
+            # Load agent - this should include AGENTS.md even without skills dir
+            loaded_agent = agent_store.load()
+
+            assert loaded_agent is not None
+            assert loaded_agent.agent_context is not None
+
+            # Verify that AGENTS.md was loaded as a skill
+            all_skills = loaded_agent.agent_context.skills
+            skill_names = [skill.name for skill in all_skills]
+
+            # The "agents" skill should be present (from AGENTS.md)
+            assert "agents" in skill_names, (
+                f"AGENTS.md should be loaded as 'agents' skill. "
+                f"Found skills: {skill_names}"
+            )
+
+            # Verify the content is correct
+            agents_skill = next(s for s in all_skills if s.name == "agents")
+            assert "Project Guidelines" in agents_skill.content
+            assert agents_skill.trigger is None  # Third-party skills are always active
+
+    def test_load_agents_md_with_skills_directory(
+        self, temp_project_dir_with_agents_md_and_skills
+    ):
+        """Test that AGENTS.md is loaded alongside skills from .openhands/skills.
+
+        Verifies that when both AGENTS.md and .openhands/skills exist,
+        both are loaded without duplicates.
+        """
+        from openhands.sdk import LLM, Agent
+
+        with patch(
+            "openhands_cli.stores.agent_store.WORK_DIR",
+            temp_project_dir_with_agents_md_and_skills,
+        ):
+            from openhands_cli.stores import AgentStore
+
+            agent_store = AgentStore()
+
+            # Create a test agent to save first
+            test_agent = Agent(llm=LLM(model="gpt-4o-mini"))
+            agent_store.save(test_agent)
+
+            # Load agent
+            loaded_agent = agent_store.load()
+
+            assert loaded_agent is not None
+            assert loaded_agent.agent_context is not None
+
+            all_skills = loaded_agent.agent_context.skills
+            skill_names = [skill.name for skill in all_skills]
+
+            # Both AGENTS.md and the skill from .openhands/skills should be loaded
+            assert "agents" in skill_names, (
+                f"AGENTS.md should be loaded. Found skills: {skill_names}"
+            )
+            assert "test_skill" in skill_names, (
+                f"test_skill should be loaded. Found skills: {skill_names}"
+            )
+
+    def test_load_third_party_skills_function_directly(
+        self, temp_project_dir_with_agents_md_only
+    ):
+        """Test the load_third_party_skills_from_work_dir function directly."""
+        from openhands_cli.stores.agent_store import (
+            load_third_party_skills_from_work_dir,
+        )
+
+        skills = load_third_party_skills_from_work_dir(
+            temp_project_dir_with_agents_md_only
+        )
+
+        assert len(skills) == 1
+        assert skills[0].name == "agents"
+        assert "Project Guidelines" in skills[0].content
+        assert skills[0].trigger is None
+
+    def test_load_third_party_skills_empty_directory(self):
+        """Test that function returns empty list for empty directory."""
+        from openhands_cli.stores.agent_store import (
+            load_third_party_skills_from_work_dir,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skills = load_third_party_skills_from_work_dir(temp_dir)
+            assert skills == []
+
+    def test_load_third_party_skills_case_insensitive(self):
+        """Test that third-party skill files are loaded case-insensitively."""
+        from openhands_cli.stores.agent_store import (
+            load_third_party_skills_from_work_dir,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create agents.md (lowercase)
+            agents_md = Path(temp_dir) / "agents.md"
+            agents_md.write_text("# Lowercase agents.md content")
+
+            skills = load_third_party_skills_from_work_dir(temp_dir)
+
+            assert len(skills) == 1
+            assert skills[0].name == "agents"
+
+    def test_load_multiple_third_party_files(self):
+        """Test loading multiple third-party skill files."""
+        from openhands_cli.stores.agent_store import (
+            load_third_party_skills_from_work_dir,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create AGENTS.md
+            agents_md = Path(temp_dir) / "AGENTS.md"
+            agents_md.write_text("# AGENTS.md content")
+
+            # Create .cursorrules
+            cursorrules = Path(temp_dir) / ".cursorrules"
+            cursorrules.write_text("# Cursor rules content")
+
+            skills = load_third_party_skills_from_work_dir(temp_dir)
+
+            assert len(skills) == 2
+            skill_names = [s.name for s in skills]
+            assert "agents" in skill_names
+            assert "cursorrules" in skill_names


### PR DESCRIPTION
## Summary

Fixes #300 - AGENTS.md files are not loaded by the CLI (i.e., don't appear in the system prompt).

## Problem

The root cause is a bug in the SDK's `load_project_skills()` function. Third-party skill files like AGENTS.md are only checked inside `load_skills_from_dir()`, but that function is only called if the `.openhands/skills` or `.openhands/microagents` directories exist.

This means if a project has an AGENTS.md file but no `.openhands/skills` directory, the AGENTS.md file is never loaded.

## Solution

This PR adds a workaround in the CLI to ensure third-party skill files are loaded regardless of whether the skills directories exist:

1. Added a new function `load_third_party_skills_from_work_dir()` that:
   - Directly scans the work directory for third-party skill files
   - Uses case-insensitive matching (handles AGENTS.md, agents.md, Agents.md, etc.)
   - Supports all known third-party files: AGENTS.md, AGENT.md, CLAUDE.md, GEMINI.md, .cursorrules

2. Integrated this function into `AgentStore.load()` to merge third-party skills with project skills, avoiding duplicates.

## Tests Added

- `test_load_agents_md_without_skills_directory`: Main bug fix test - verifies AGENTS.md is loaded even when `.openhands/skills` doesn't exist
- `test_load_agents_md_with_skills_directory`: Verifies no duplicates when both AGENTS.md and skills directory exist
- `test_load_third_party_skills_function_directly`: Unit test for the new function
- `test_load_third_party_skills_empty_directory`: Edge case test for empty directory
- `test_load_third_party_skills_case_insensitive`: Verifies case-insensitive file matching
- `test_load_multiple_third_party_files`: Tests loading multiple third-party files

## Note on SDK Bug

The underlying bug is in the SDK's `load_project_skills()` function in `openhands/sdk/context/skills/skill.py`. A proper fix should be made in the SDK to check for third-party files even when skills directories don't exist. This PR provides a workaround in the CLI until the SDK is fixed.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/83f3dc2ce58142c0a793856525bf898f)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/fix-agents-md-loading
```