### PR TITLE
Add stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,23 +1,28 @@
+---
 # Workflow that marks issues and PRs with no activity for 40 days with "Stale" and closes them after 10 more days of no activity
-name: 'Close stale issues'
+name: Close stale issues
 
 # Runs every day at 01:30
 on:
-  schedule:
-    - cron: '30 1 * * *'
+    schedule:
+        - cron: 30 1 * * *
 
 jobs:
-  stale:
-    runs-on: ubuntu-latest
-    if: github.repository == 'OpenHands/OpenHands-CLI'
-    steps:
-      - uses: actions/stale@v9
-        with:
-          stale-issue-message: 'This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment, otherwise it will be closed in 10 days.'
-          stale-pr-message: 'This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment, otherwise it will be closed in 10 days.'
-          days-before-stale: 40
-          exempt-issue-labels: roadmap,backlog
-          close-issue-message: 'This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat manageable and focus on active issues.'
-          close-pr-message: 'This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would like to continue the PR, please resubmit or let us know.'
-          days-before-close: 10
-          operations-per-run: 300
+    stale:
+        runs-on: ubuntu-latest
+        if: github.repository == 'OpenHands/OpenHands-CLI'
+        steps:
+            - uses: actions/stale@v9
+              with:
+                  stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a 
+                      comment, otherwise it will be closed in 10 days.
+                  stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,
+                      otherwise it will be closed in 10 days.
+                  days-before-stale: 40
+                  exempt-issue-labels: roadmap,backlog
+                  close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat 
+                      manageable and focus on active issues.
+                  close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would 
+                      like to continue the PR, please resubmit or let us know.
+                  days-before-close: 10
+                  operations-per-run: 300


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically manage stale issues and PRs.

## Changes
- Added `.github/workflows/stale.yml` workflow that:
  - Runs daily at 01:30 UTC
  - Marks issues and PRs as stale after 40 days of inactivity
  - Closes stale issues/PRs after 10 additional days (50 days total) without activity
  - Exempts issues with `roadmap` or `backlog` labels
  - Processes up to 300 operations per run

This workflow is modeled after the stale workflow in the main [OpenHands repository](https://github.com/OpenHands/OpenHands/blob/main/.github/workflows/stale.yml), adapted for the OpenHands-CLI repository.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@add-stale-workflow
```