### PR TITLE
Print raw JSON when event validation fails

### DIFF
--- a/openhands_cli/conversations/viewer.py
+++ b/openhands_cli/conversations/viewer.py
@@ -120,6 +120,7 @@ class ConversationViewer:
         Returns:
             The parsed Event object, or None if parsing failed.
         """
+        event_data = None
         try:
             with open(event_file, encoding="utf-8") as f:
                 event_data = json.load(f)
@@ -129,6 +130,11 @@ class ConversationViewer:
                 f"Warning: Could not parse event file {event_file.name}: {e}",
                 style=OPENHANDS_THEME.warning,
             )
+            if event_data is not None:
+                console.print(
+                    f"Raw JSON: {json.dumps(event_data, indent=2)}",
+                    style=OPENHANDS_THEME.secondary,
+                )
             return None
 
 


### PR DESCRIPTION
## Summary

This PR improves error handling in the conversation viewer by printing the raw JSON content when a validation error occurs while parsing event files.

## Problem

When viewing a conversation with events that have schema mismatches (e.g., extra fields not permitted), users only see a warning message like:

```
Warning: Could not parse event file event-00004-6f9b4ef0-c6e9-46e2-b385-93a9fbcd5a61.json: 1 validation error for Event
summary
  Extra inputs are not permitted
```

This makes it difficult to debug what's wrong with the event file.

## Solution

Now when a validation error occurs, the viewer prints both:
1. The warning message (as before)
2. The raw JSON content of the event file

This helps users understand what data caused the validation error.

## Changes

- `openhands_cli/conversations/viewer.py`: Modified `_load_event` method to print raw JSON when validation fails
- `tests/test_conversation_viewer.py`: Added test case to verify raw JSON is printed on validation errors

## Testing

All tests pass including the new test case:
```bash
uv run pytest tests/test_conversation_viewer.py -v
```

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/print-raw-json-on-validation-error
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/eb3a3f3e41f642d19ae4194f41802f45)