### PR TITLE
auth: prefer verification_uri_complete for OAuth device flow

### DIFF
--- a/openhands_cli/auth/device_flow.py
+++ b/openhands_cli/auth/device_flow.py
@@ -44,7 +44,7 @@ class DeviceFlowClient(BaseHttpClient):
             return (
                 result["device_code"],
                 result["user_code"],
-                result["verification_uri"],
+                result.get("verification_uri_complete") or result["verification_uri"],
                 result["interval"],
             )
         except (AuthHttpError, KeyError) as e:
@@ -141,8 +141,13 @@ class DeviceFlowClient(BaseHttpClient):
             _p(f"[{OPENHANDS_THEME.error}]Error: {e}[/{OPENHANDS_THEME.error}]")
             raise
 
-        # Step 2: Construct URL with user_code parameter and open browser
-        verification_url = f"{verification_uri}?user_code={user_code}"
+        # Step 2: Open browser to verification URL
+        # OpenHands may return a complete URL; but our tests (and older servers)
+        # expect/return a base verification_uri without the query param.
+        if "user_code=" in verification_uri:
+            verification_url = verification_uri
+        else:
+            verification_url = f"{verification_uri}?user_code={user_code}"
 
         _p(
             f"\n[{OPENHANDS_THEME.warning}]Opening your web browser for "


### PR DESCRIPTION
HUMAN: this is a tiny detail that was found by OpenHands agent when it checked the code against the server code.

—-

### Context
OpenHands server's `/oauth/device/authorize` response includes `verification_uri_complete` (a full verification URL already containing `user_code`). OpenHands-CLI previously always constructed `verification_uri + ?user_code=...`, which can be redundant or incorrect if the server already returns a complete URL.

### Changes
- In `DeviceFlowClient.start_device_flow`, prefer `verification_uri_complete` when present, otherwise fall back to `verification_uri`.
- When opening the browser, avoid double-appending `user_code` if it’s already present.

### Verification
- `uv run pytest` ✅
- `make lint` ✅

Co-authored-by: openhands <openhands@all-hands.dev>


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8406558e9a8444e6be92de6a0bed8921)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands-workspace-ct24pfge
```