### PR TITLE
fix: Correctly format LLM model names for litellm providers

### DIFF
--- a/openhands_cli/tui/modals/settings/choices.py
+++ b/openhands_cli/tui/modals/settings/choices.py
@@ -1,20 +1,49 @@
+import litellm
+
 from openhands.sdk.llm import UNVERIFIED_MODELS_EXCLUDING_BEDROCK, VERIFIED_MODELS
 
 
+# Get set of valid litellm provider names for filtering
+# See: https://docs.litellm.ai/docs/providers
+_VALID_LITELLM_PROVIDERS: set[str] = {
+    str(getattr(p, "value", p)) for p in litellm.provider_list
+}
+
+
 def get_provider_options() -> list[tuple[str, str]]:
-    """Get list of available LLM providers."""
-    providers = list(VERIFIED_MODELS.keys()) + list(
-        UNVERIFIED_MODELS_EXCLUDING_BEDROCK.keys()
-    )
-    return [(provider, provider) for provider in providers]
+    """Get list of available LLM providers.
+
+    Includes:
+    - All VERIFIED_MODELS providers (openhands, openai, anthropic, mistral)
+      even if not in litellm.provider_list (e.g. 'openhands' is custom)
+    - UNVERIFIED providers that are known to litellm (filters out invalid
+      "providers" like 'meta-llama', 'Qwen' which are vendor names)
+
+    Sorted alphabetically.
+    """
+    # Verified providers always included (includes custom like 'openhands')
+    verified_providers = set(VERIFIED_MODELS.keys())
+
+    # Unverified providers are filtered to only valid litellm providers
+    unverified_providers = set(UNVERIFIED_MODELS_EXCLUDING_BEDROCK.keys())
+    valid_unverified = unverified_providers & _VALID_LITELLM_PROVIDERS
+
+    # Combine and sort
+    all_valid_providers = sorted(verified_providers | valid_unverified)
+
+    return [(provider, provider) for provider in all_valid_providers]
 
 
 def get_model_options(provider: str) -> list[tuple[str, str]]:
-    """Get list of available models for a provider."""
+    """Get list of available models for a provider, sorted alphabetically."""
     models = VERIFIED_MODELS.get(
         provider, []
     ) + UNVERIFIED_MODELS_EXCLUDING_BEDROCK.get(provider, [])
-    return [(model, model) for model in models]
+
+    # Remove duplicates and sort
+    unique_models = sorted(set(models))
+
+    return [(model, model) for model in unique_models]
 
 
 provider_options = get_provider_options()

--- a/openhands_cli/tui/modals/settings/utils.py
+++ b/openhands_cli/tui/modals/settings/utils.py
@@ -79,10 +79,11 @@ class SettingsFormData(BaseModel):
             return str(self.custom_model)
 
         model_str = str(self.model)
-        full_model = (
-            f"{self.provider}/{model_str}" if "/" not in model_str else model_str
-        )
-        return full_model
+
+        # Always add provider prefix - litellm requires it for routing.
+        # Even if model contains '/' (e.g. "openai/gpt-4.1" from openrouter)
+        # See: https://docs.litellm.ai/docs/providers
+        return f"{self.provider}/{model_str}"
 
 
 class SettingsSaveResult(BaseModel):

--- a/tests/tui/modals/settings/test_settings_utils.py
+++ b/tests/tui/modals/settings/test_settings_utils.py
@@ -133,6 +133,40 @@ def test_preserves_existing_api_key_when_not_provided(
             ("custom_model", "base_url"),
         ),
         (
+            "basic",
+            "openrouter",
+            "google/gemini-3-flash-preview",
+            "should-be-cleared",
+            "https://advanced.example",
+            # All providers require prefix even for models with '/' in their name
+            # See: https://docs.litellm.ai/docs/providers/openrouter
+            "openrouter/google/gemini-3-flash-preview",
+            None,
+            ("custom_model", "base_url"),
+        ),
+        (
+            "basic",
+            "nvidia_nim",
+            "meta/llama3-70b-instruct",
+            "should-be-cleared",
+            "https://advanced.example",
+            # See: https://docs.litellm.ai/docs/providers/nvidia_nim
+            "nvidia_nim/meta/llama3-70b-instruct",
+            None,
+            ("custom_model", "base_url"),
+        ),
+        (
+            "basic",
+            "deepinfra",
+            "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "should-be-cleared",
+            "https://advanced.example",
+            # See: https://docs.litellm.ai/docs/providers
+            "deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct",
+            None,
+            ("custom_model", "base_url"),
+        ),
+        (
             "advanced",
             "openai",
             "gpt-4o",


### PR DESCRIPTION
## Summary

Fixes LLM provider routing issues when using providers like OpenRouter, Nvidia NIM, DeepInfra, etc. where model names already contain `/` (e.g., `openai/gpt-4.1` from OpenRouter).

Also cleans up the provider list by filtering out invalid "providers" that are actually vendor names.

## Problem

When selecting a provider like `openrouter` with model `google/gemini-3-flash-preview`, the model name was saved as `google/gemini-3-flash-preview` instead of the required `openrouter/google/gemini-3-flash-preview`. This caused litellm to fail with:

```
LLM Provider NOT provided. Pass in the LLM provider you are trying to call.
```

Additionally, the provider dropdown contained ~116 entries including invalid "providers" like `meta-llama`, `other`, `1024-x-1024` that were parsed from model names in the SDK.

## Changes

### 1. `openhands_cli/tui/modals/settings/utils.py`
- Always add provider prefix in `get_full_model_name()` regardless of `/` in model name
- This matches litellm documentation for all providers

### 2. `openhands_cli/tui/modals/settings/choices.py`
- Always include VERIFIED_MODELS providers (`openhands`, `openai`, `anthropic`, `mistral`)
- Filter UNVERIFIED providers to only include valid litellm providers
- Sort providers and models alphabetically, remove duplicates

### 3. `tests/tui/modals/settings/test_settings_utils.py`
- Added test cases for openrouter, nvidia_nim, and deepinfra providers

## Testing

All 603 tests pass.

## Before/After

**Provider list:** 116+ entries → 60 valid providers (sorted alphabetically)

| Provider | Model | Before | After |
|----------|-------|--------|-------|
| openrouter | `google/gemini-3-flash-preview` | `google/gemini-3-flash-preview` ❌ | `openrouter/google/gemini-3-flash-preview` ✅ |
| nvidia_nim | `meta/llama3-70b-instruct` | `meta/llama3-70b-instruct` ❌ | `nvidia_nim/meta/llama3-70b-instruct` ✅ |
| openhands | `claude-sonnet-4-5-20250929` | `openhands/claude-sonnet-4-5-20250929` ✅ | `openhands/claude-sonnet-4-5-20250929` ✅ |