### PR TITLE
Truncate long terminal commands in collapsed view

### DIFF
--- a/openhands_cli/tui/widgets/richlog_visualizer.py
+++ b/openhands_cli/tui/widgets/richlog_visualizer.py
@@ -189,9 +189,13 @@ class ConversationVisualizer(ConversationVisualizerBase):
     def _build_action_title(self, event: ActionEvent) -> str:
         """Build a title for an action event.
 
-        Format: "[bold]{summary}[/bold]" for most actions
-                "[bold]{summary}[/bold]: $ {command}" for terminal actions
-                "[bold]{summary}[/bold]: Reading/Editing {path}" for file operations
+        Format:
+            "[bold]{summary}[/bold]" for most actions
+            "[bold]{summary}[/bold][dim]: $ {command}[/dim]" for terminal
+            "[bold]{summary}[/bold][dim]: Reading/Editing {path}[/dim]" for files
+
+        The detail portion (after the colon) is rendered in dim style to
+        visually distinguish it from the main summary text.
         """
         summary = (
             self._escape_rich_markup(str(event.summary).strip().replace("\n", " "))
@@ -205,16 +209,16 @@ class ConversationVisualizer(ConversationVisualizerBase):
             cmd = self._escape_rich_markup(action.command.strip().replace("\n", " "))
             cmd = self._truncate_for_display(cmd)
             if summary:
-                return f"[bold]{summary}[/bold]: $ {cmd}"
-            return f"$ {cmd}"
+                return f"[bold]{summary}[/bold][dim]: $ {cmd}[/dim]"
+            return f"[dim]$ {cmd}[/dim]"
 
         # File operations: include path with Reading/Editing
         if isinstance(action, FileEditorAction) and action.path:
             op = "Reading" if action.command == "view" else "Editing"
             path = self._escape_rich_markup(action.path)
             if summary:
-                return f"[bold]{summary}[/bold]: {op} {path}"
-            return f"[bold]{op}[/bold] {path}"
+                return f"[bold]{summary}[/bold][dim]: {op} {path}[/dim]"
+            return f"[bold]{op}[/bold][dim] {path}[/dim]"
 
         # All other actions: just use summary
         if summary:

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -638,7 +638,9 @@ EOF"""
         action_event = create_terminal_action_event(long_cmd, summary=None)
 
         title = visualizer._build_action_title(action_event)
-        assert title.startswith("$ ")
+        # Command without summary is wrapped in [dim] tags
+        assert title.startswith("[dim]$ ")
+        assert title.endswith("[/dim]")
         assert "..." in title
 
     def test_truncate_from_end_for_paths(self, visualizer):


### PR DESCRIPTION
## Summary

Improves the collapsed cell header display for action events with two enhancements:
1. **Truncates long terminal commands** to maintain single-line display
2. **Dims the detail text** (commands, paths) to create visual hierarchy

## Problem

When the agent executes long terminal commands (e.g., complex curl POSTs, multi-line heredoc file writes), the collapsed cell header would display the entire command, causing it to span multiple lines. This made the conversation history harder to scan.

Additionally, the summary text and detail text (like `$ command` or `Reading /path/to/file`) were both rendered in the same bright white, making it harder to quickly scan and distinguish the meaningful description from the implementation details.

## Solution

### 1. Command Truncation
Added truncation logic to `_build_action_title()` in `richlog_visualizer.py`:
- Commands longer than 70 characters are truncated with `...`
- The full command remains visible when the cell is expanded
- Multiline commands are flattened to a single line before truncation

### 2. Visual Hierarchy with Dim Styling
Added Rich `[dim]` markup to the detail portion of action titles:
- **Bold white**: Main summary text (e.g., "List all Python files in current directory")
- **Dim white**: Detail text after the colon (e.g., `: $ find . -name "*.py"`)
- **White**: Status checkmark (✓) remains bright

### 3. Unified Truncation Helper
Refactored existing truncation code into a reusable `_truncate_for_display()` method:
- Consolidates 8 separate inline truncation implementations
- Supports both start-truncation (for commands) and end-truncation (for paths to preserve filename)
- Uses consistent `MAX_LINE_LENGTH = 70` constant throughout

## Behavior Changes

| Before | After |
|--------|-------|
| Long commands displayed in full, wrapping to multiple lines | Commands truncated to 70 chars with `...` |
| Summary and details both rendered in bright white | Details rendered in dim color for visual hierarchy |
| Inconsistent truncation limits (50, 57, 60, 67 chars) | Unified 70-char limit via `MAX_LINE_LENGTH` constant |

## Changes

- Modified `openhands_cli/tui/widgets/richlog_visualizer.py`:
  - Added `MAX_LINE_LENGTH` and `ELLIPSIS` constants
  - Added `_truncate_for_display()` helper method
  - Updated `_build_action_title()` to truncate commands and add dim styling
  - Refactored `_extract_meaningful_title()` to use the new helper
- Added comprehensive unit tests for truncation behavior

## Testing

All tests pass:
```
tests/tui/widgets/test_richlog_visualizer.py - 37 tests PASSED
```

Fixes #334

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@jps/trunc-long-cli-commands
```
