### PR TITLE
chore: Remove unused 'Display Cost Per Action' setting

### DIFF
--- a/openhands_cli/stores/cli_settings.py
+++ b/openhands_cli/stores/cli_settings.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 class CliSettings(BaseModel):
     """Model for CLI-level settings."""
 
-    display_cost_per_action: bool = False
     default_cells_expanded: bool = True
     auto_open_plan_panel: bool = True
 

--- a/openhands_cli/tui/modals/settings/components/cli_settings_tab.py
+++ b/openhands_cli/tui/modals/settings/components/cli_settings_tab.py
@@ -54,16 +54,6 @@ class CliSettingsTab(Container):
             yield Static("CLI Settings", classes="form_section_title")
 
             yield SettingsSwitch(
-                label="Display Cost Per Action",
-                description=(
-                    "Show the estimated cost for each action performed "
-                    "by the agent in the interface."
-                ),
-                switch_id="display_cost_switch",
-                value=self.cli_settings.display_cost_per_action,
-            )
-
-            yield SettingsSwitch(
                 label="Default Cells Expanded",
                 description=(
                     "When enabled, new action/observation cells will be expanded "
@@ -87,7 +77,6 @@ class CliSettingsTab(Container):
 
     def get_cli_settings(self) -> CliSettings:
         """Get the current CLI settings from the form."""
-        display_cost_switch = self.query_one("#display_cost_switch", Switch)
         default_cells_expanded_switch = self.query_one(
             "#default_cells_expanded_switch", Switch
         )
@@ -96,7 +85,6 @@ class CliSettingsTab(Container):
         )
 
         return CliSettings(
-            display_cost_per_action=display_cost_switch.value,
             default_cells_expanded=default_cells_expanded_switch.value,
             auto_open_plan_panel=auto_open_plan_panel_switch.value,
         )

--- a/tests/tui/modals/settings/test_cli_settings.py
+++ b/tests/tui/modals/settings/test_cli_settings.py
@@ -11,14 +11,8 @@ from openhands_cli.stores import CliSettings
 class TestCliSettings:
     def test_defaults(self):
         cfg = CliSettings()
-        assert cfg.display_cost_per_action is False
         assert cfg.default_cells_expanded is True
         assert cfg.auto_open_plan_panel is True
-
-    @pytest.mark.parametrize("value", [True, False])
-    def test_model_accepts_bool(self, value: bool):
-        cfg = CliSettings(display_cost_per_action=value)
-        assert cfg.display_cost_per_action is value
 
     @pytest.mark.parametrize("value", [True, False])
     def test_default_cells_expanded_accepts_bool(self, value: bool):
@@ -60,18 +54,18 @@ class TestCliSettings:
     @pytest.mark.parametrize(
         "file_content, expected",
         [
-            (json.dumps({"display_cost_per_action": True}), True),
-            (json.dumps({"display_cost_per_action": False}), False),
-            (json.dumps({}), False),  # missing field -> default
-            ("not json", False),  # JSONDecodeError -> defaults
+            (json.dumps({"default_cells_expanded": True}), True),
+            (json.dumps({"default_cells_expanded": False}), False),
+            (json.dumps({}), True),  # missing field -> default
+            ("not json", True),  # JSONDecodeError -> defaults
             (
-                json.dumps({"display_cost_per_action": "nope"}),
-                False,
+                json.dumps({"default_cells_expanded": "nope"}),
+                True,
             ),  # ValidationError -> caught -> defaults
             (
                 json.dumps({"unknown_field": True}),
-                False,
-            ),  # extra ignored; still default False
+                True,
+            ),  # extra ignored; still default True
         ],
     )
     def test_load_various_inputs(
@@ -83,11 +77,11 @@ class TestCliSettings:
         with patch.object(CliSettings, "get_config_path", return_value=config_path):
             cfg = CliSettings.load()
 
-        assert cfg.display_cost_per_action is expected
+        assert cfg.default_cells_expanded is expected
 
     def test_load_permission_error_propagates(self, tmp_path: Path):
         config_path = tmp_path / "cli_config.json"
-        config_path.write_text(json.dumps({"display_cost_per_action": True}))
+        config_path.write_text(json.dumps({"default_cells_expanded": True}))
 
         with patch.object(CliSettings, "get_config_path", return_value=config_path):
             with patch("builtins.open", side_effect=PermissionError("Access denied")):
@@ -97,19 +91,18 @@ class TestCliSettings:
     @pytest.mark.parametrize("value", [True, False])
     def test_save_creates_parent_dir_and_roundtrips(self, tmp_path: Path, value: bool):
         config_path = tmp_path / "nested" / "dir" / "cli_config.json"
-        cfg = CliSettings(display_cost_per_action=value)
+        cfg = CliSettings(default_cells_expanded=value)
 
         with patch.object(CliSettings, "get_config_path", return_value=config_path):
             cfg.save()
             assert config_path.exists()
             loaded = CliSettings.load()
 
-        assert loaded.display_cost_per_action is value
+        assert loaded.default_cells_expanded is value
 
     def test_save_writes_expected_json_format(self, tmp_path: Path):
         config_path = tmp_path / "cli_config.json"
         cfg = CliSettings(
-            display_cost_per_action=True,
             default_cells_expanded=False,
             auto_open_plan_panel=False,
         )
@@ -119,7 +112,6 @@ class TestCliSettings:
 
         assert config_path.read_text() == json.dumps(
             {
-                "display_cost_per_action": True,
                 "default_cells_expanded": False,
                 "auto_open_plan_panel": False,
             },
@@ -128,7 +120,7 @@ class TestCliSettings:
 
     def test_save_permission_error_propagates(self, tmp_path: Path):
         config_path = tmp_path / "cli_config.json"
-        cfg = CliSettings(display_cost_per_action=True)
+        cfg = CliSettings(default_cells_expanded=True)
 
         with patch.object(CliSettings, "get_config_path", return_value=config_path):
             with patch("builtins.open", side_effect=PermissionError("Access denied")):

--- a/tests/tui/modals/settings/test_cli_settings_tab.py
+++ b/tests/tui/modals/settings/test_cli_settings_tab.py
@@ -27,64 +27,15 @@ class _TestApp(App):
 
 
 class TestCliSettingsTab:
-    @pytest.mark.parametrize("display_cost_per_action", [True, False])
-    def test_init_calls_load_and_stores_config(self, display_cost_per_action: bool):
-        cfg = CliSettings(display_cost_per_action=display_cost_per_action)
+    @pytest.mark.parametrize("default_cells_expanded", [True, False])
+    def test_init_calls_load_and_stores_config(self, default_cells_expanded: bool):
+        cfg = CliSettings(default_cells_expanded=default_cells_expanded)
 
         with patch.object(CliSettings, "load", return_value=cfg) as mock_load:
             tab = CliSettingsTab()
 
         mock_load.assert_called_once()
         assert tab.cli_settings == cfg
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("initial_value", [True, False])
-    async def test_compose_renders_switch_with_loaded_value(self, initial_value: bool):
-        cfg = CliSettings(display_cost_per_action=initial_value)
-        app = _TestApp(cfg)
-
-        async with app.run_test():
-            tab = app.query_one(CliSettingsTab)
-            switch = tab.query_one("#display_cost_switch", Switch)
-            assert switch.value is initial_value
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "initial_value, new_value",
-        [
-            (False, True),
-            (True, False),
-        ],
-    )
-    async def test_get_cli_settings_reflects_current_switch_value(
-        self, initial_value: bool, new_value: bool
-    ):
-        cfg = CliSettings(display_cost_per_action=initial_value)
-        app = _TestApp(cfg)
-
-        async with app.run_test():
-            tab = app.query_one(CliSettingsTab)
-            switch = tab.query_one("#display_cost_switch", Switch)
-
-            # simulate user change
-            switch.value = new_value
-
-            result = tab.get_cli_settings()
-            assert isinstance(result, CliSettings)
-            assert result.display_cost_per_action is new_value
-
-    @pytest.mark.asyncio
-    async def test_switch_click_toggles_state(self):
-        cfg = CliSettings(display_cost_per_action=False)
-        app = _TestApp(cfg)
-
-        async with app.run_test() as pilot:
-            tab = app.query_one(CliSettingsTab)
-            switch = tab.query_one("#display_cost_switch", Switch)
-
-            assert switch.value is False
-            await pilot.click(switch)
-            assert switch.value is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("initial_value", [True, False])

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -63,9 +63,9 @@ def mock_cli_settings():
 
 
 @pytest.fixture
-def mock_cli_settings_with_cost(mock_cli_settings):
-    """Provide mock CliSettings with display_cost_per_action=True."""
-    return mock_cli_settings(display_cost_per_action=True)
+def mock_cli_settings_with_defaults(mock_cli_settings):
+    """Provide mock CliSettings with default values."""
+    return mock_cli_settings()
 
 
 # ============================================================================
@@ -369,7 +369,7 @@ class TestCliSettingsCaching:
     def test_cli_settings_caching(self, visualizer):
         """Test that app configuration is cached and not loaded repeatedly."""
         with patch("openhands_cli.stores.CliSettings.load") as mock_load:
-            mock_config = CliSettings(display_cost_per_action=True)
+            mock_config = CliSettings(default_cells_expanded=True)
             mock_load.return_value = mock_config
 
             # First call should load from file
@@ -390,8 +390,8 @@ class TestCliSettingsCaching:
     def test_cli_settings_refresh(self, visualizer):
         """Test that reload_configuration reloads the configuration."""
         with patch("openhands_cli.stores.CliSettings.load") as mock_load:
-            mock_config1 = CliSettings(display_cost_per_action=False)
-            mock_config2 = CliSettings(display_cost_per_action=True)
+            mock_config1 = CliSettings(default_cells_expanded=False)
+            mock_config2 = CliSettings(default_cells_expanded=True)
             mock_load.side_effect = [mock_config1, mock_config2]
 
             # First call should load from file
@@ -411,13 +411,13 @@ class TestCliSettingsCaching:
     def test_reload_configuration_clears_cache(self, visualizer):
         """Test that reload_configuration properly clears the cached configuration."""
         with patch("openhands_cli.stores.CliSettings.load") as mock_load:
-            config1 = CliSettings(display_cost_per_action=False)
-            config2 = CliSettings(display_cost_per_action=True)
+            config1 = CliSettings(default_cells_expanded=False)
+            config2 = CliSettings(default_cells_expanded=True)
             mock_load.side_effect = [config1, config2]
 
             # First access should load config1
             first_config = visualizer.cli_settings
-            assert first_config.display_cost_per_action is False
+            assert first_config.default_cells_expanded is False
             assert mock_load.call_count == 1
 
             # Reload should clear cache and load config2
@@ -426,7 +426,7 @@ class TestCliSettingsCaching:
 
             # Next access should return config2 (from cache)
             second_config = visualizer.cli_settings
-            assert second_config.display_cost_per_action is True
+            assert second_config.default_cells_expanded is True
             assert mock_load.call_count == 2  # No additional load
 
     @pytest.mark.parametrize(
@@ -439,12 +439,12 @@ class TestCliSettingsCaching:
         """Test cli_settings property behavior with different initial cache states."""
         # Set initial cache state
         if initial_cache_state == "cached_config":
-            visualizer._cli_settings = CliSettings(display_cost_per_action=True)
+            visualizer._cli_settings = CliSettings(default_cells_expanded=False)
         else:
             visualizer._cli_settings = None
 
         with patch("openhands_cli.stores.CliSettings.load") as mock_load:
-            mock_config = CliSettings(display_cost_per_action=False)
+            mock_config = CliSettings(default_cells_expanded=True)
             mock_load.return_value = mock_config
 
             result = visualizer.cli_settings
@@ -454,7 +454,7 @@ class TestCliSettingsCaching:
                 assert result == mock_config
             else:
                 assert mock_load.call_count == 0
-                assert result.display_cost_per_action is True
+                assert result.default_cells_expanded is False
 
 
 class TestCommandTruncation:


### PR DESCRIPTION
## Summary

After PR #331 added cost metrics to the status bar, the "Display Cost Per Action" setting in CLI Settings is no longer needed. This PR removes the unused setting.

## Changes

- Removed `display_cost_per_action` field from `CliSettings` model
- Removed "Display Cost Per Action" switch from CLI Settings tab
- Updated related tests

## Context

PR #331 introduced a status bar that shows context window usage and accumulated cost with token details. This made the per-action cost display setting obsolete since cost information is now always visible in the status bar.

## Testing

- All existing tests pass
- Linting passes

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3eea94ec08f14adc82ca3fbff2a61a20)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/remove-display-cost-per-action-setting
```