### PR TITLE
Chore: remove --exp feature flag

### DIFF
--- a/e2e_tests/test_experimental_ui.py
+++ b/e2e_tests/test_experimental_ui.py
@@ -11,7 +11,7 @@ from .utils import seed_dummy_settings
 
 
 def test_experimental_ui() -> TestResult:
-    """Test the experimental textual UI with --exp flag."""
+    """Test the textual UI."""
     test_name = "experimental_ui"
     start_time = time.time()
 
@@ -36,7 +36,7 @@ def test_experimental_ui() -> TestResult:
 
             boot_start = time.time()
             proc = subprocess.Popen(
-                [str(exe_path), "--exp", "--exit-without-confirmation"],
+                [str(exe_path), "--exit-without-confirmation"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/openhands_cli/argparsers/main_parser.py
+++ b/openhands_cli/argparsers/main_parser.py
@@ -31,7 +31,6 @@ def create_main_parser() -> argparse.ArgumentParser:
 
             Examples:
                 openhands                           # Start textual UI mode
-                openhands --exp                     # Start textual UI (same as default)
                 openhands --headless                # Start textual UI in headless mode
                 openhands --headless --json -t "Fix bug"  # Headless with JSON output
                 openhands --resume conversation-id  # Resume conversation
@@ -74,11 +73,6 @@ def create_main_parser() -> argparse.ArgumentParser:
 
     # CLI arguments at top level (default mode)
     add_resume_args(parser)
-    parser.add_argument(
-        "--exp",
-        action="store_true",
-        help="Use textual-based UI (now default, flag kept for compatibility)",
-    )
     parser.add_argument(
         "--headless",
         action="store_true",

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -190,8 +190,7 @@ def main() -> None:
                 # Either showed conversation list or had an error
                 return
 
-            # Use textual-based UI as default (experimental UI is now the default)
-            # The --exp flag is kept for compatibility but does the same thing
+            # Use textual-based UI as default
             from openhands_cli.tui.textual_app import main as textual_main
 
             queued_inputs = create_seeded_instructions_from_args(args)

--- a/openhands_cli/tui/serve.py
+++ b/openhands_cli/tui/serve.py
@@ -13,5 +13,5 @@ def launch_web_server(
         port: Port to bind the web server to
         debug: Enable debug mode for the web server
     """
-    server = Server("uv run openhands --exp", host=host, port=port)
+    server = Server("uv run openhands", host=host, port=port)
     server.serve(debug=debug)

--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -208,8 +208,8 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
                 console.print(
                     f"[{OPENHANDS_THEME.error}]Headless mode requires existing "
                     f"settings.[/{OPENHANDS_THEME.error}]\n"
-                    f"[bold]Please run:[/bold] [{OPENHANDS_THEME.success}]openhands "
-                    f"--exp[/{OPENHANDS_THEME.success}] to configure your settings "
+                    f"[bold]Please run:[/bold] [{OPENHANDS_THEME.success}]openhands"
+                    f"[/{OPENHANDS_THEME.success}] to configure your settings "
                     f"before using [{OPENHANDS_THEME.accent}]--headless"
                     f"[/{OPENHANDS_THEME.accent}]."
                 )

--- a/tests/test_web_command.py
+++ b/tests/test_web_command.py
@@ -96,7 +96,7 @@ def test_launch_web_server_constructs_and_serves(
     launch_web_server(**kwargs)
 
     mock_server_class.assert_called_once_with(
-        "uv run openhands --exp",
+        "uv run openhands",
         host=expected_host,
         port=expected_port,
     )

--- a/tests/tui/test_headless_mode.py
+++ b/tests/tui/test_headless_mode.py
@@ -385,13 +385,13 @@ class TestHeadlessInitialSetupGuard:
             # Should NOT try to open the interactive settings screen
             app._show_initial_settings.assert_not_called()
 
-            # We should have printed a message that mentions `openhands --exp`
-            printed_any_exp_hint = any(
-                "openhands --exp" in str(arg)
+            # We should have printed a message that mentions `openhands`
+            printed_any_hint = any(
+                "openhands" in str(arg)
                 for call in mock_console.print.call_args_list
                 for arg in call.args
             )
-            assert printed_any_exp_hint
+            assert printed_any_hint
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Remove the `--exp` feature flag which was kept for backward compatibility but is no longer needed since the textual UI is now the default behavior.

## Changes

- Remove the `--exp` argument definition from `main_parser.py`
- Remove `openhands --exp` example from the help text
- Update `serve.py` to use `"uv run openhands"` instead of `"uv run openhands --exp"`
- Update user-facing message in `textual_app.py` to reference just `openhands` instead of `openhands --exp`
- Remove comment in `entrypoint.py` mentioning the `--exp` flag
- Update test assertions in `test_web_command.py` and `test_headless_mode.py`
- Update `e2e_tests/test_experimental_ui.py` to run without `--exp` flag

## Testing

- All 34 related tests pass
- `make lint` passes (Ruff format, Ruff lint, PEP8, pyright)

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@remove-exp-feature-flag
```