### PR TITLE
(Hotfix): CLI crashes when opening MCP panel

### DIFF
--- a/openhands_cli/tui/panels/mcp_side_panel.py
+++ b/openhands_cli/tui/panels/mcp_side_panel.py
@@ -197,10 +197,24 @@ class MCPSidePanel(VerticalScroll):
 
         return details
 
+    def _server_spec_to_dict(
+        self, server_spec: StdioMCPServer | RemoteMCPServer | dict
+    ) -> dict:
+        """Convert a server specification to a dictionary for comparison.
+
+        Handles both Pydantic model objects (StdioMCPServer, RemoteMCPServer)
+        and plain dictionaries.
+        """
+        if isinstance(server_spec, StdioMCPServer | RemoteMCPServer):
+            return server_spec.model_dump()
+        return server_spec
+
     def _check_server_specs_are_equal(
         self, first_server_spec, second_server_spec
     ) -> bool:
         """Check if two server specifications are equal."""
-        first_stringified_server_spec = json.dumps(first_server_spec, sort_keys=True)
-        second_stringified_server_spec = json.dumps(second_server_spec, sort_keys=True)
+        first_dict = self._server_spec_to_dict(first_server_spec)
+        second_dict = self._server_spec_to_dict(second_server_spec)
+        first_stringified_server_spec = json.dumps(first_dict, sort_keys=True)
+        second_stringified_server_spec = json.dumps(second_dict, sort_keys=True)
         return first_stringified_server_spec == second_stringified_server_spec

--- a/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_empty_state.svg
+++ b/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_empty_state.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #e0e0e0 }
+.terminal-r2 { fill: #c5c8c6 }
+.terminal-r3 { fill: #4f4f4f }
+.terminal-r4 { fill: #0178d4;font-weight: bold }
+.terminal-r5 { fill: #e0e0e0;font-weight: bold }
+.terminal-r6 { fill: #ffe165 }
+.terminal-r7 { fill: #495259 }
+.terminal-r8 { fill: #ffa62b;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">MCPPanelEmptyApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="1.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="50.3" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="74.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="74.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="99.1" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="99.1" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="123.5" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="123.5" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="147.9" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1195.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="172.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="196.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="221.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="245.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="269.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="294.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="318.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="343.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="367.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="391.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="416.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="440.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="465.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="489.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="513.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="538.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="562.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="587.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="611.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="635.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="660.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="684.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="709.1" width="1073.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1073.6" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1085.8" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1110.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1207.8" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-line-0)">Main&#160;content&#160;area</text><text class="terminal-r3" x="817.4" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▏</text><text class="terminal-r4" x="841.8" y="20" textLength="134.2" clip-path="url(#terminal-line-0)">MCP&#160;Servers</text><text class="terminal-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r3" x="817.4" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▏</text><text class="terminal-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r3" x="817.4" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▏</text><text class="terminal-r5" x="841.8" y="68.8" textLength="268.4" clip-path="url(#terminal-line-2)">Current&#160;Agent&#160;Servers:</text><text class="terminal-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r3" x="817.4" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▏</text><text class="terminal-r6" x="841.8" y="93.2" textLength="207.4" clip-path="url(#terminal-line-3)">&#160;&#160;None&#160;configured</text><text class="terminal-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="817.4" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▏</text><text class="terminal-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r3" x="817.4" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">▏</text><text class="terminal-r6" x="841.8" y="142" textLength="256.2" clip-path="url(#terminal-line-5)">Config&#160;file&#160;not&#160;found</text><text class="terminal-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="817.4" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▏</text><text class="terminal-r1" x="841.8" y="166.4" textLength="353.8" clip-path="url(#terminal-line-6)">Create:&#160;~/.openhands/mcp.json</text><text class="terminal-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r3" x="817.4" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▏</text><text class="terminal-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r3" x="817.4" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▏</text><text class="terminal-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r3" x="817.4" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">▏</text><text class="terminal-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r3" x="817.4" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">▏</text><text class="terminal-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r3" x="817.4" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▏</text><text class="terminal-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="817.4" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▏</text><text class="terminal-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="817.4" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▏</text><text class="terminal-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="817.4" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">▏</text><text class="terminal-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="817.4" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">▏</text><text class="terminal-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="817.4" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▏</text><text class="terminal-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="817.4" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▏</text><text class="terminal-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="817.4" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▏</text><text class="terminal-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="817.4" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▏</text><text class="terminal-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="817.4" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▏</text><text class="terminal-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="817.4" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▏</text><text class="terminal-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">▏</text><text class="terminal-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r3" x="817.4" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">▏</text><text class="terminal-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r3" x="817.4" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">▏</text><text class="terminal-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r3" x="817.4" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">▏</text><text class="terminal-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r3" x="817.4" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">▏</text><text class="terminal-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r3" x="817.4" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">▏</text><text class="terminal-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r3" x="817.4" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">▏</text><text class="terminal-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r7" x="1073.6" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">▏</text><text class="terminal-r8" x="1085.8" y="727.6" textLength="24.4" clip-path="url(#terminal-line-29)">^p</text><text class="terminal-r1" x="1110.2" y="727.6" textLength="97.6" clip-path="url(#terminal-line-29)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_mixed_servers.svg
+++ b/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_mixed_servers.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #e0e0e0 }
+.terminal-r2 { fill: #c5c8c6 }
+.terminal-r3 { fill: #4f4f4f }
+.terminal-r4 { fill: #0178d4;font-weight: bold }
+.terminal-r5 { fill: #e0e0e0;font-weight: bold }
+.terminal-r6 { fill: #ffe165 }
+.terminal-r7 { fill: #495259 }
+.terminal-r8 { fill: #ffa62b;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">MCPPanelMixedServersApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="1.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="50.3" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="74.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="99.1" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="99.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="123.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="147.9" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1159" y="147.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="172.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1000.4" y="172.3" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="196.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="196.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="221.1" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="221.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="245.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="245.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="269.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1207.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="294.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="951.6" y="294.3" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="318.7" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="318.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="343.1" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="343.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="367.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1195.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="391.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="416.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="440.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="465.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="489.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="513.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="538.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="562.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="587.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="611.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="635.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="660.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="684.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="709.1" width="1073.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1073.6" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1085.8" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1110.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1207.8" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-line-0)">Main&#160;content&#160;area</text><text class="terminal-r3" x="817.4" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▏</text><text class="terminal-r4" x="841.8" y="20" textLength="134.2" clip-path="url(#terminal-line-0)">MCP&#160;Servers</text><text class="terminal-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r3" x="817.4" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▏</text><text class="terminal-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r3" x="817.4" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▏</text><text class="terminal-r5" x="841.8" y="68.8" textLength="268.4" clip-path="url(#terminal-line-2)">Current&#160;Agent&#160;Servers:</text><text class="terminal-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r3" x="817.4" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▏</text><text class="terminal-r6" x="841.8" y="93.2" textLength="97.6" clip-path="url(#terminal-line-3)">•&#160;notion</text><text class="terminal-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="817.4" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▏</text><text class="terminal-r1" x="841.8" y="117.6" textLength="207.4" clip-path="url(#terminal-line-4)">&#160;&#160;Type:&#160;URL-based</text><text class="terminal-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r3" x="817.4" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">▏</text><text class="terminal-r1" x="841.8" y="142" textLength="73.2" clip-path="url(#terminal-line-5)">&#160;&#160;URL:</text><text class="terminal-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="817.4" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▏</text><text class="terminal-r1" x="841.8" y="166.4" textLength="317.2" clip-path="url(#terminal-line-6)">https://mcp.notion.com/mcp</text><text class="terminal-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r3" x="817.4" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▏</text><text class="terminal-r1" x="841.8" y="190.8" textLength="158.6" clip-path="url(#terminal-line-7)">&#160;&#160;Auth:&#160;oauth</text><text class="terminal-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r3" x="817.4" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▏</text><text class="terminal-r6" x="841.8" y="215.2" textLength="146.4" clip-path="url(#terminal-line-8)">•&#160;local_tool</text><text class="terminal-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r3" x="817.4" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">▏</text><text class="terminal-r1" x="841.8" y="239.6" textLength="256.2" clip-path="url(#terminal-line-9)">&#160;&#160;Type:&#160;Command-based</text><text class="terminal-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r3" x="817.4" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">▏</text><text class="terminal-r1" x="841.8" y="264" textLength="170.8" clip-path="url(#terminal-line-10)">&#160;&#160;Command:&#160;npx</text><text class="terminal-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r3" x="817.4" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▏</text><text class="terminal-r1" x="841.8" y="288.4" textLength="366" clip-path="url(#terminal-line-11)">@modelcontextprotocol/server-f</text><text class="terminal-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="817.4" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▏</text><text class="terminal-r1" x="841.8" y="312.8" textLength="109.8" clip-path="url(#terminal-line-12)">ilesystem</text><text class="terminal-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="817.4" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▏</text><text class="terminal-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="817.4" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">▏</text><text class="terminal-r6" x="841.8" y="361.6" textLength="256.2" clip-path="url(#terminal-line-14)">Config&#160;file&#160;not&#160;found</text><text class="terminal-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="817.4" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">▏</text><text class="terminal-r1" x="841.8" y="386" textLength="353.8" clip-path="url(#terminal-line-15)">Create:&#160;~/.openhands/mcp.json</text><text class="terminal-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="817.4" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▏</text><text class="terminal-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="817.4" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▏</text><text class="terminal-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="817.4" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▏</text><text class="terminal-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="817.4" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▏</text><text class="terminal-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="817.4" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▏</text><text class="terminal-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="817.4" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▏</text><text class="terminal-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">▏</text><text class="terminal-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r3" x="817.4" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">▏</text><text class="terminal-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r3" x="817.4" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">▏</text><text class="terminal-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r3" x="817.4" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">▏</text><text class="terminal-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r3" x="817.4" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">▏</text><text class="terminal-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r3" x="817.4" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">▏</text><text class="terminal-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r3" x="817.4" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">▏</text><text class="terminal-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r7" x="1073.6" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">▏</text><text class="terminal-r8" x="1085.8" y="727.6" textLength="24.4" clip-path="url(#terminal-line-29)">^p</text><text class="terminal-r1" x="1110.2" y="727.6" textLength="97.6" clip-path="url(#terminal-line-29)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_remote_servers.svg
+++ b/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_remote_servers.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #e0e0e0 }
+.terminal-r2 { fill: #c5c8c6 }
+.terminal-r3 { fill: #4f4f4f }
+.terminal-r4 { fill: #0178d4;font-weight: bold }
+.terminal-r5 { fill: #e0e0e0;font-weight: bold }
+.terminal-r6 { fill: #ffe165 }
+.terminal-r7 { fill: #495259 }
+.terminal-r8 { fill: #ffa62b;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">MCPPanelWithRemoteServersApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="1.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="50.3" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="74.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="99.1" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="99.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="123.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="147.9" width="317.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1159" y="147.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="172.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1000.4" y="172.3" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="196.7" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="196.7" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="221.1" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="221.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="245.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="245.5" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="269.9" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1171.2" y="269.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="294.3" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="988.2" y="294.3" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="318.7" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="318.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="343.1" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="343.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="367.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1195.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="391.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="416.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="440.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="465.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="489.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="513.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="538.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="562.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="587.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="611.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="635.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="660.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="684.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="709.1" width="1073.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1073.6" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1085.8" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1110.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1207.8" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-line-0)">Main&#160;content&#160;area</text><text class="terminal-r3" x="817.4" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▏</text><text class="terminal-r4" x="841.8" y="20" textLength="134.2" clip-path="url(#terminal-line-0)">MCP&#160;Servers</text><text class="terminal-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r3" x="817.4" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▏</text><text class="terminal-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r3" x="817.4" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▏</text><text class="terminal-r5" x="841.8" y="68.8" textLength="268.4" clip-path="url(#terminal-line-2)">Current&#160;Agent&#160;Servers:</text><text class="terminal-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r3" x="817.4" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▏</text><text class="terminal-r6" x="841.8" y="93.2" textLength="97.6" clip-path="url(#terminal-line-3)">•&#160;notion</text><text class="terminal-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="817.4" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▏</text><text class="terminal-r1" x="841.8" y="117.6" textLength="207.4" clip-path="url(#terminal-line-4)">&#160;&#160;Type:&#160;URL-based</text><text class="terminal-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r3" x="817.4" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">▏</text><text class="terminal-r1" x="841.8" y="142" textLength="73.2" clip-path="url(#terminal-line-5)">&#160;&#160;URL:</text><text class="terminal-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="817.4" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▏</text><text class="terminal-r1" x="841.8" y="166.4" textLength="317.2" clip-path="url(#terminal-line-6)">https://mcp.notion.com/mcp</text><text class="terminal-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r3" x="817.4" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▏</text><text class="terminal-r1" x="841.8" y="190.8" textLength="158.6" clip-path="url(#terminal-line-7)">&#160;&#160;Auth:&#160;oauth</text><text class="terminal-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r3" x="817.4" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▏</text><text class="terminal-r6" x="841.8" y="215.2" textLength="146.4" clip-path="url(#terminal-line-8)">•&#160;api_server</text><text class="terminal-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r3" x="817.4" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">▏</text><text class="terminal-r1" x="841.8" y="239.6" textLength="207.4" clip-path="url(#terminal-line-9)">&#160;&#160;Type:&#160;URL-based</text><text class="terminal-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r3" x="817.4" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">▏</text><text class="terminal-r1" x="841.8" y="264" textLength="73.2" clip-path="url(#terminal-line-10)">&#160;&#160;URL:</text><text class="terminal-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r3" x="817.4" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▏</text><text class="terminal-r1" x="841.8" y="288.4" textLength="329.4" clip-path="url(#terminal-line-11)">https://api.example.com/mcp</text><text class="terminal-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="817.4" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▏</text><text class="terminal-r1" x="841.8" y="312.8" textLength="146.4" clip-path="url(#terminal-line-12)">&#160;&#160;Auth:&#160;none</text><text class="terminal-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="817.4" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▏</text><text class="terminal-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="817.4" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">▏</text><text class="terminal-r6" x="841.8" y="361.6" textLength="256.2" clip-path="url(#terminal-line-14)">Config&#160;file&#160;not&#160;found</text><text class="terminal-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="817.4" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">▏</text><text class="terminal-r1" x="841.8" y="386" textLength="353.8" clip-path="url(#terminal-line-15)">Create:&#160;~/.openhands/mcp.json</text><text class="terminal-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="817.4" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▏</text><text class="terminal-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="817.4" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▏</text><text class="terminal-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="817.4" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▏</text><text class="terminal-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="817.4" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▏</text><text class="terminal-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="817.4" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▏</text><text class="terminal-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="817.4" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▏</text><text class="terminal-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">▏</text><text class="terminal-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r3" x="817.4" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">▏</text><text class="terminal-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r3" x="817.4" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">▏</text><text class="terminal-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r3" x="817.4" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">▏</text><text class="terminal-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r3" x="817.4" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">▏</text><text class="terminal-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r3" x="817.4" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">▏</text><text class="terminal-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r3" x="817.4" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">▏</text><text class="terminal-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r7" x="1073.6" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">▏</text><text class="terminal-r8" x="1085.8" y="727.6" textLength="24.4" clip-path="url(#terminal-line-29)">^p</text><text class="terminal-r1" x="1110.2" y="727.6" textLength="97.6" clip-path="url(#terminal-line-29)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_stdio_servers.svg
+++ b/tests/snapshots/__snapshots__/test_app_snapshots/TestMCPSidePanelSnapshots.test_mcp_panel_with_stdio_servers.svg
@@ -1,0 +1,180 @@
+<svg class="rich-terminal" viewBox="0 0 1238 782.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #e0e0e0 }
+.terminal-r2 { fill: #c5c8c6 }
+.terminal-r3 { fill: #4f4f4f }
+.terminal-r4 { fill: #0178d4;font-weight: bold }
+.terminal-r5 { fill: #e0e0e0;font-weight: bold }
+.terminal-r6 { fill: #ffe165 }
+.terminal-r7 { fill: #495259 }
+.terminal-r8 { fill: #ffa62b;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="731.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="780" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">MCPPanelWithStdioServersApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="207.4" y="1.5" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="1.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="50.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="50.3" width="268.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="74.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="74.7" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="99.1" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="99.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="123.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1085.8" y="123.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="147.9" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="172.3" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="172.3" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="196.7" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="196.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="841.8" y="221.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1195.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="245.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="269.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="294.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="318.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="343.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="367.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="391.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="416.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="440.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="465.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="489.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="513.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="538.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="562.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="587.1" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="611.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="611.5" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="635.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="635.9" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="660.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="660.3" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="817.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="817.4" y="684.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="684.7" width="390.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="709.1" width="1073.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1073.6" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1085.8" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1110.2" y="709.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1207.8" y="709.1" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-line-0)">Main&#160;content&#160;area</text><text class="terminal-r3" x="817.4" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">▏</text><text class="terminal-r4" x="841.8" y="20" textLength="134.2" clip-path="url(#terminal-line-0)">MCP&#160;Servers</text><text class="terminal-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r3" x="817.4" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">▏</text><text class="terminal-r2" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r3" x="817.4" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">▏</text><text class="terminal-r5" x="841.8" y="68.8" textLength="268.4" clip-path="url(#terminal-line-2)">Current&#160;Agent&#160;Servers:</text><text class="terminal-r2" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r3" x="817.4" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">▏</text><text class="terminal-r6" x="841.8" y="93.2" textLength="170.8" clip-path="url(#terminal-line-3)">•&#160;local_server</text><text class="terminal-r2" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="817.4" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">▏</text><text class="terminal-r1" x="841.8" y="117.6" textLength="256.2" clip-path="url(#terminal-line-4)">&#160;&#160;Type:&#160;Command-based</text><text class="terminal-r2" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r3" x="817.4" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">▏</text><text class="terminal-r1" x="841.8" y="142" textLength="244" clip-path="url(#terminal-line-5)">&#160;&#160;Command:&#160;python&#160;-m</text><text class="terminal-r2" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="817.4" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▏</text><text class="terminal-r1" x="841.8" y="166.4" textLength="122" clip-path="url(#terminal-line-6)">mcp_server</text><text class="terminal-r2" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r3" x="817.4" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">▏</text><text class="terminal-r2" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r3" x="817.4" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">▏</text><text class="terminal-r6" x="841.8" y="215.2" textLength="256.2" clip-path="url(#terminal-line-8)">Config&#160;file&#160;not&#160;found</text><text class="terminal-r2" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r3" x="817.4" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">▏</text><text class="terminal-r1" x="841.8" y="239.6" textLength="353.8" clip-path="url(#terminal-line-9)">Create:&#160;~/.openhands/mcp.json</text><text class="terminal-r2" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r3" x="817.4" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">▏</text><text class="terminal-r2" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r3" x="817.4" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">▏</text><text class="terminal-r2" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r3" x="817.4" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">▏</text><text class="terminal-r2" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r3" x="817.4" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">▏</text><text class="terminal-r2" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r3" x="817.4" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">▏</text><text class="terminal-r2" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r3" x="817.4" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">▏</text><text class="terminal-r2" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r3" x="817.4" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">▏</text><text class="terminal-r2" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r3" x="817.4" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">▏</text><text class="terminal-r2" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r3" x="817.4" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">▏</text><text class="terminal-r2" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r3" x="817.4" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▏</text><text class="terminal-r2" x="1220" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r3" x="817.4" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">▏</text><text class="terminal-r2" x="1220" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r3" x="817.4" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">▏</text><text class="terminal-r2" x="1220" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r3" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">▏</text><text class="terminal-r2" x="1220" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r3" x="817.4" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">▏</text><text class="terminal-r2" x="1220" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r3" x="817.4" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">▏</text><text class="terminal-r2" x="1220" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r3" x="817.4" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">▏</text><text class="terminal-r2" x="1220" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r3" x="817.4" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">▏</text><text class="terminal-r2" x="1220" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r3" x="817.4" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">▏</text><text class="terminal-r2" x="1220" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r3" x="817.4" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">▏</text><text class="terminal-r2" x="1220" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r7" x="1073.6" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">▏</text><text class="terminal-r8" x="1085.8" y="727.6" textLength="24.4" clip-path="url(#terminal-line-29)">^p</text><text class="terminal-r1" x="1110.2" y="727.6" textLength="97.6" clip-path="url(#terminal-line-29)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshots/test_app_snapshots.py
+++ b/tests/snapshots/test_app_snapshots.py
@@ -14,19 +14,29 @@ For more information:
     https://github.com/Textualize/pytest-textual-snapshot
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
+from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Footer, Static
 
 from openhands.tools.task_tracker.definition import TaskItem
 from openhands_cli.tui.modals.exit_modal import ExitConfirmationModal
+from openhands_cli.tui.panels.mcp_side_panel import MCPSidePanel
 from openhands_cli.tui.panels.plan_side_panel import PlanSidePanel
 
 
 if TYPE_CHECKING:
     pass
+
+
+def _create_mock_agent(mcp_config: dict[str, Any] | None = None) -> Any:
+    """Create a mock Agent with MCP configuration."""
+    mock_agent = MagicMock()
+    mock_agent.mcp_config = mcp_config or {"mcpServers": {}}
+    return mock_agent
 
 
 class TestExitModalSnapshots:
@@ -166,4 +176,176 @@ class TestPlanSidePanelSnapshots:
 
         assert snap_compare(
             PlanPanelAllDoneApp(tasks=task_list), terminal_size=(100, 30)
+        )
+
+
+class TestMCPSidePanelSnapshots:
+    """Snapshot tests for the MCPSidePanel."""
+
+    def test_mcp_panel_empty_state(self, snap_compare):
+        """Snapshot test for MCP panel with no servers configured."""
+        mock_agent = _create_mock_agent({"mcpServers": {}})
+
+        class MCPPanelEmptyApp(App):
+            CSS = """
+            Screen {
+                layout: horizontal;
+            }
+            #main_content {
+                width: 2fr;
+            }
+            """
+
+            def __init__(self, agent, **kwargs):
+                super().__init__(**kwargs)
+                self._agent = agent
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content area", id="main_content")
+                yield Footer()
+
+            def on_mount(self) -> None:
+                panel = MCPSidePanel(agent=self._agent)
+                content_area = self.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+
+        assert snap_compare(MCPPanelEmptyApp(agent=mock_agent), terminal_size=(100, 30))
+
+    def test_mcp_panel_with_remote_servers(self, snap_compare):
+        """Snapshot test for MCP panel with RemoteMCPServer objects.
+
+        This test verifies the fix for issue #362 where RemoteMCPServer
+        objects caused a crash when opening the MCP menu.
+        """
+        mcp_config = {
+            "mcpServers": {
+                "notion": RemoteMCPServer(
+                    url="https://mcp.notion.com/mcp",
+                    transport="http",
+                    auth="oauth",
+                ),
+                "api_server": RemoteMCPServer(
+                    url="https://api.example.com/mcp",
+                    transport="http",
+                    headers={"Authorization": "Bearer token"},
+                ),
+            }
+        }
+        mock_agent = _create_mock_agent(mcp_config)
+
+        class MCPPanelWithRemoteServersApp(App):
+            CSS = """
+            Screen {
+                layout: horizontal;
+            }
+            #main_content {
+                width: 2fr;
+            }
+            """
+
+            def __init__(self, agent, **kwargs):
+                super().__init__(**kwargs)
+                self._agent = agent
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content area", id="main_content")
+                yield Footer()
+
+            def on_mount(self) -> None:
+                panel = MCPSidePanel(agent=self._agent)
+                content_area = self.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+
+        assert snap_compare(
+            MCPPanelWithRemoteServersApp(agent=mock_agent), terminal_size=(100, 30)
+        )
+
+    def test_mcp_panel_with_stdio_servers(self, snap_compare):
+        """Snapshot test for MCP panel with StdioMCPServer objects."""
+        mcp_config = {
+            "mcpServers": {
+                "local_server": StdioMCPServer(
+                    command="python",
+                    args=["-m", "mcp_server"],
+                    transport="stdio",
+                    env={"API_KEY": "secret"},
+                ),
+            }
+        }
+        mock_agent = _create_mock_agent(mcp_config)
+
+        class MCPPanelWithStdioServersApp(App):
+            CSS = """
+            Screen {
+                layout: horizontal;
+            }
+            #main_content {
+                width: 2fr;
+            }
+            """
+
+            def __init__(self, agent, **kwargs):
+                super().__init__(**kwargs)
+                self._agent = agent
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content area", id="main_content")
+                yield Footer()
+
+            def on_mount(self) -> None:
+                panel = MCPSidePanel(agent=self._agent)
+                content_area = self.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+
+        assert snap_compare(
+            MCPPanelWithStdioServersApp(agent=mock_agent), terminal_size=(100, 30)
+        )
+
+    def test_mcp_panel_with_mixed_servers(self, snap_compare):
+        """Snapshot test for MCP panel with both remote and stdio servers."""
+        mcp_config = {
+            "mcpServers": {
+                "notion": RemoteMCPServer(
+                    url="https://mcp.notion.com/mcp",
+                    transport="http",
+                    auth="oauth",
+                ),
+                "local_tool": StdioMCPServer(
+                    command="npx",
+                    args=["@modelcontextprotocol/server-filesystem"],
+                    transport="stdio",
+                ),
+            }
+        }
+        mock_agent = _create_mock_agent(mcp_config)
+
+        class MCPPanelMixedServersApp(App):
+            CSS = """
+            Screen {
+                layout: horizontal;
+            }
+            #main_content {
+                width: 2fr;
+            }
+            """
+
+            def __init__(self, agent, **kwargs):
+                super().__init__(**kwargs)
+                self._agent = agent
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content area", id="main_content")
+                yield Footer()
+
+            def on_mount(self) -> None:
+                panel = MCPSidePanel(agent=self._agent)
+                content_area = self.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+
+        assert snap_compare(
+            MCPPanelMixedServersApp(agent=mock_agent), terminal_size=(100, 30)
         )

--- a/tests/tui/panels/test_mcp_side_panel.py
+++ b/tests/tui/panels/test_mcp_side_panel.py
@@ -1,0 +1,394 @@
+"""Tests for MCPSidePanel widget."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Static
+
+from openhands_cli.tui.panels.mcp_side_panel import MCPSidePanel
+
+
+if TYPE_CHECKING:
+    pass
+
+
+def _create_mock_agent(mcp_config: dict[str, Any] | None = None) -> Any:
+    """Create a mock Agent with MCP configuration."""
+    mock_agent = MagicMock()
+    mock_agent.mcp_config = mcp_config or {"mcpServers": {}}
+    return mock_agent
+
+
+# ============================================================================
+# Test App Helper
+# ============================================================================
+
+
+class MCPPanelTestApp(App):
+    """Test app for mounting MCPSidePanel."""
+
+    CSS = """
+    Screen { layout: horizontal; }
+    #main_content { width: 2fr; }
+    """
+
+    def __init__(self, agent: Any = None, **kwargs):
+        super().__init__(**kwargs)
+        self._agent = agent
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="content_area"):
+            yield Static("Main content", id="main_content")
+
+
+# ============================================================================
+# _check_server_specs_are_equal Tests
+# ============================================================================
+
+
+class TestCheckServerSpecsAreEqual:
+    """Tests for MCPSidePanel._check_server_specs_are_equal method."""
+
+    def test_equal_dict_specs(self):
+        """Verify equal dict specs return True."""
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        spec1 = {"url": "https://example.com", "transport": "http"}
+        spec2 = {"url": "https://example.com", "transport": "http"}
+
+        result = panel._check_server_specs_are_equal(spec1, spec2)
+        assert result is True
+
+    def test_different_dict_specs(self):
+        """Verify different dict specs return False."""
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        spec1 = {"url": "https://example.com", "transport": "http"}
+        spec2 = {"url": "https://other.com", "transport": "http"}
+
+        result = panel._check_server_specs_are_equal(spec1, spec2)
+        assert result is False
+
+    def test_remote_mcp_server_objects_are_serializable(self):
+        """Test that RemoteMCPServer objects can be compared without JSON error.
+
+        This test reproduces the bug from issue #362 where RemoteMCPServer
+        objects caused TypeError: Object of type RemoteMCPServer is not JSON
+        serializable.
+        """
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        # Create RemoteMCPServer objects (as they would be in agent.mcp_config)
+        server1 = RemoteMCPServer(
+            url="https://api.example.com",
+            transport="http",
+            headers={"Authorization": "Bearer token"},
+        )
+        server2 = RemoteMCPServer(
+            url="https://api.example.com",
+            transport="http",
+            headers={"Authorization": "Bearer token"},
+        )
+
+        # This should NOT raise TypeError
+        result = panel._check_server_specs_are_equal(server1, server2)
+        assert result is True
+
+    def test_stdio_mcp_server_objects_are_serializable(self):
+        """Test that StdioMCPServer objects can be compared without JSON error."""
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        # Create StdioMCPServer objects
+        server1 = StdioMCPServer(
+            command="python",
+            args=["-m", "server"],
+            transport="stdio",
+            env={"API_KEY": "secret"},
+        )
+        server2 = StdioMCPServer(
+            command="python",
+            args=["-m", "server"],
+            transport="stdio",
+            env={"API_KEY": "secret"},
+        )
+
+        # This should NOT raise TypeError
+        result = panel._check_server_specs_are_equal(server1, server2)
+        assert result is True
+
+    def test_mixed_server_and_dict_comparison(self):
+        """Test comparing a server object with a dict representation."""
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        # RemoteMCPServer object (from agent.mcp_config)
+        server_obj = RemoteMCPServer(
+            url="https://api.example.com",
+            transport="http",
+        )
+
+        # Dict representation (from get_config_status)
+        server_dict = {
+            "url": "https://api.example.com",
+            "transport": "http",
+        }
+
+        # This should NOT raise TypeError
+        result = panel._check_server_specs_are_equal(server_obj, server_dict)
+        # The result may be True or False depending on implementation,
+        # but it should not raise an exception
+        assert isinstance(result, bool)
+
+    def test_different_remote_mcp_servers(self):
+        """Test that different RemoteMCPServer objects return False."""
+        mock_agent = _create_mock_agent()
+        panel = MCPSidePanel(agent=mock_agent)
+
+        server1 = RemoteMCPServer(
+            url="https://api.example.com",
+            transport="http",
+        )
+        server2 = RemoteMCPServer(
+            url="https://other.example.com",
+            transport="http",
+        )
+
+        result = panel._check_server_specs_are_equal(server1, server2)
+        assert result is False
+
+
+# ============================================================================
+# refresh_content Tests with MCP Server Objects
+# ============================================================================
+
+
+class TestRefreshContentWithServerObjects:
+    """Tests for MCPSidePanel.refresh_content with server objects."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_content_with_remote_mcp_servers(self, tmp_path: Path):
+        """Test refresh_content handles RemoteMCPServer objects in agent config.
+
+        This test reproduces the bug from issue #362 where opening the MCP menu
+        crashed with: TypeError: Object of type RemoteMCPServer is not JSON serializable
+        """
+        # Create MCP config file with servers
+        mcp_config_data = {
+            "mcpServers": {
+                "test_server": {
+                    "url": "https://api.example.com",
+                    "transport": "http",
+                }
+            }
+        }
+        mcp_config_file = tmp_path / "mcp.json"
+        mcp_config_file.write_text(json.dumps(mcp_config_data))
+
+        # Create agent with RemoteMCPServer objects (as they would be loaded)
+        agent_mcp_config = {
+            "mcpServers": {
+                "test_server": RemoteMCPServer(
+                    url="https://api.example.com",
+                    transport="http",
+                )
+            }
+        }
+        mock_agent = _create_mock_agent(agent_mcp_config)
+
+        class TestApp(App):
+            CSS = """
+            Screen { layout: horizontal; }
+            """
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content", id="main_content")
+
+        app = TestApp()
+
+        with patch("openhands_cli.locations.PERSISTENCE_DIR", str(tmp_path)):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                panel = MCPSidePanel(agent=mock_agent)
+                content_area = app.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+                await pilot.pause()
+
+                # This should NOT raise TypeError
+                panel.refresh_content()
+
+    @pytest.mark.asyncio
+    async def test_refresh_content_with_disabled_servers(self, tmp_path: Path):
+        """Test refresh_content handles disabled servers (issue #362 scenario).
+
+        The user mentioned having some MCP servers explicitly disabled.
+        """
+        # Create MCP config file with enabled and disabled servers
+        mcp_config_data = {
+            "mcpServers": {
+                "enabled_server": {
+                    "url": "https://enabled.example.com",
+                    "transport": "http",
+                    "enabled": True,
+                },
+                "disabled_server": {
+                    "url": "https://disabled.example.com",
+                    "transport": "http",
+                    "enabled": False,
+                },
+            }
+        }
+        mcp_config_file = tmp_path / "mcp.json"
+        mcp_config_file.write_text(json.dumps(mcp_config_data))
+
+        # Create agent with RemoteMCPServer objects
+        agent_mcp_config = {
+            "mcpServers": {
+                "enabled_server": RemoteMCPServer(
+                    url="https://enabled.example.com",
+                    transport="http",
+                ),
+                "disabled_server": RemoteMCPServer(
+                    url="https://disabled.example.com",
+                    transport="http",
+                ),
+            }
+        }
+        mock_agent = _create_mock_agent(agent_mcp_config)
+
+        class TestApp(App):
+            CSS = """
+            Screen { layout: horizontal; }
+            """
+
+            def compose(self) -> ComposeResult:
+                with Horizontal(id="content_area"):
+                    yield Static("Main content", id="main_content")
+
+        app = TestApp()
+
+        with patch("openhands_cli.locations.PERSISTENCE_DIR", str(tmp_path)):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                panel = MCPSidePanel(agent=mock_agent)
+                content_area = app.query_one("#content_area", Horizontal)
+                content_area.mount(panel)
+                await pilot.pause()
+
+                # This should NOT raise TypeError
+                panel.refresh_content()
+
+
+# ============================================================================
+# toggle Tests
+# ============================================================================
+
+
+class TestToggle:
+    """Tests for MCPSidePanel.toggle class method."""
+
+    @pytest.mark.asyncio
+    async def test_toggle_mounts_panel(self, tmp_path: Path):
+        """Verify toggle() mounts the panel."""
+        app = MCPPanelTestApp()
+
+        with patch("openhands_cli.locations.PERSISTENCE_DIR", str(tmp_path)):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                # Toggle to mount
+                MCPSidePanel.toggle(app)
+                await pilot.pause()
+
+                # Verify panel is mounted
+                panels = app.query(MCPSidePanel)
+                assert len(panels) == 1
+
+    @pytest.mark.asyncio
+    async def test_toggle_removes_panel(self, tmp_path: Path):
+        """Verify toggle() removes an existing panel."""
+        app = MCPPanelTestApp()
+
+        with patch("openhands_cli.locations.PERSISTENCE_DIR", str(tmp_path)):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                # Toggle to mount
+                MCPSidePanel.toggle(app)
+                await pilot.pause()
+
+                # Toggle to remove
+                MCPSidePanel.toggle(app)
+                await pilot.pause()
+
+                # Verify panel is removed
+                panels = app.query(MCPSidePanel)
+                assert len(panels) == 0
+
+    @pytest.mark.asyncio
+    async def test_toggle_with_remote_mcp_servers_in_agent(self, tmp_path: Path):
+        """Test toggle works when agent has RemoteMCPServer objects.
+
+        This is the main reproduction test for issue #362.
+        """
+        # Create MCP config file
+        mcp_config_data = {
+            "mcpServers": {
+                "notion": {
+                    "url": "https://mcp.notion.com/mcp",
+                    "transport": "http",
+                    "auth": "oauth",
+                }
+            }
+        }
+        mcp_config_file = tmp_path / "mcp.json"
+        mcp_config_file.write_text(json.dumps(mcp_config_data))
+
+        # Create agent settings with RemoteMCPServer objects
+        agent_mcp_config = {
+            "mcpServers": {
+                "notion": RemoteMCPServer(
+                    url="https://mcp.notion.com/mcp",
+                    transport="http",
+                    auth="oauth",
+                )
+            }
+        }
+
+        # Create a mock agent that will be returned by AgentStore.load()
+        mock_agent = _create_mock_agent(agent_mcp_config)
+
+        app = MCPPanelTestApp()
+
+        with (
+            patch("openhands_cli.locations.PERSISTENCE_DIR", str(tmp_path)),
+            patch("openhands_cli.stores.AgentStore") as mock_agent_store_class,
+        ):
+            mock_agent_store = MagicMock()
+            mock_agent_store.load.return_value = mock_agent
+            mock_agent_store_class.return_value = mock_agent_store
+
+            async with app.run_test() as pilot:
+                await pilot.pause()
+
+                # This should NOT raise TypeError
+                MCPSidePanel.toggle(app)
+                await pilot.pause()
+
+                # Verify panel is mounted
+                panels = app.query(MCPSidePanel)
+                assert len(panels) == 1


### PR DESCRIPTION
## Summary

This PR fixes issue #362 where the CLI crashes when opening the MCP menu with the error:
```
TypeError: Object of type RemoteMCPServer is not JSON serializable
```

## Root Cause

The `_check_server_specs_are_equal` method in `MCPSidePanel` was trying to JSON serialize `RemoteMCPServer` and `StdioMCPServer` Pydantic model objects directly. When the agent's MCP configuration contains these objects (which happens when servers are loaded), the JSON serialization fails.

## Solution

Added a `_server_spec_to_dict` helper method that converts Pydantic model objects to dictionaries using `model_dump()` before JSON serialization. This ensures that both server objects and plain dictionaries can be compared correctly.

## Changes

- **openhands_cli/tui/panels/mcp_side_panel.py**: Added `_server_spec_to_dict` method and updated `_check_server_specs_are_equal` to use it
- **tests/tui/panels/test_mcp_side_panel.py**: Added comprehensive unit tests for the MCP side panel, including tests that reproduce the bug
- **tests/snapshots/test_app_snapshots.py**: Added screenshot tests for the MCP panel with various server configurations

## Testing

All tests pass:
- 11 new unit tests for the MCP side panel
- 4 new screenshot tests for the MCP panel
- All existing MCP tests continue to pass (100 tests total)

Fixes #362

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e5c99831a6614a14acf4f319e44595ad)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/fix-mcp-panel-json-serialization-362
```