### PR TITLE
fix: Issue with memory condensation not being editable

### DIFF
--- a/openhands_cli/tui/modals/settings/settings_screen.py
+++ b/openhands_cli/tui/modals/settings/settings_screen.py
@@ -225,6 +225,14 @@ class SettingsScreen(ModalScreen):
             self.basic_section.display = True
             self.advanced_section.display = False
 
+    def _has_existing_api_key(self) -> bool:
+        """Check if there's an existing API key in the agent."""
+        return bool(
+            self.current_agent
+            and self.current_agent.llm
+            and self.current_agent.llm.api_key
+        )
+
     def _update_field_dependencies(self) -> None:
         """Update field enabled/disabled state based on dependency chain."""
         try:
@@ -289,7 +297,8 @@ class SettingsScreen(ModalScreen):
                     pass
 
             # Memory Condensation: enabled when API key is provided
-            self.memory_select.disabled = not api_key
+            # or when there's an existing API key in the agent
+            self.memory_select.disabled = not (api_key or self._has_existing_api_key())
 
         except Exception:
             # Silently handle errors during initialization


### PR DESCRIPTION
**Closes #264**

### Description

Fixes Memory Condensation field not being editable when reopening the Settings tab with an existing API key. Previously, the field remained disabled because the code only checked if the API key input field had a value, but when loading existing settings, the input field is intentionally left empty (to allow users to keep the current key by leaving it blank).

#### Changes

- **Updated `settings_screen.py`**: 
  - Added `_has_existing_api_key()` helper method to check if the agent has a saved API key
  - Updated `_update_field_dependencies()` to enable Memory Condensation when either:
    - The API key input field has a value, OR
    - There's an existing API key in the saved agent (even if input is empty)
- **Updated tests**: Added test cases to verify Memory Condensation is enabled/disabled correctly in various scenarios:
  - Enabled when reopening settings with existing API key
  - Disabled when no API key exists in saved agent
  - Disabled when API key input is empty and no existing agent

#### Testing
- [x] Manually Verified

1. Start CLI: `uv run openhands`
2. Open Settings: `ctrl + p`
3. Set API key and save (with Memory Condensation disabled)
4. Reopen Settings
5. Verify Memory Condensation field is now editable

- [x] Unit tests added and passing

#### PR submission checklist
- [x] Scope is minimal and focused on one change
- [x] Tests added/updated for behavior changes
- [x] `make lint`
```bash
(openhands) ➜  OpenHands-CLI git:(bevani/issue_264) make lint
uv run pre-commit run --all-files
Format YAML files........................................................Passed
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
```
- [x] `make test`
```bash
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------- snapshot report summary ---------------------------------------------------------------------
11 snapshots passed.
================================================================ 981 passed, 4 warnings in 38.19s ================================================================
```
- [x] (If TUI touched) snapshot tests run and snapshots updated/reviewed
- [x] PR description includes: what changed, why, commands run, and UI evidence (snapshots/screenshots)