### PR TITLE
Fix capitalization in command palette for Plan and Settings

### DIFF
--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -185,11 +185,11 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
             "MCP", "View MCP configurations", lambda: MCPSidePanel.toggle(self)
         )
         yield SystemCommand(
-            "PLAN",
+            "Plan",
             "View agent plan",
             lambda: self.plan_panel.toggle(),
         )
-        yield SystemCommand("SETTINGS", "Configure settings", self.action_open_settings)
+        yield SystemCommand("Settings", "Configure settings", self.action_open_settings)
 
     def on_mount(self) -> None:
         """Called when app starts."""


### PR DESCRIPTION
## Summary
Fixes inconsistent capitalization in the command palette where "PLAN" and "SETTINGS" were displayed in all caps while other commands used title case.

## Changes
- Changed `"PLAN"` → `"Plan"` 
- Changed `"SETTINGS"` → `"Settings"`
- `"MCP"` remains all caps as it's an acronym

## Before
- PLAN
- SETTINGS

## After
- Plan
- Settings

This makes the command palette consistent with other entries like "Keys", "Maximize", "Quit", "Screenshot", and "Theme".

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix-command-palette-capitalization
```