### PR TITLE
Preserve condenser settings from agent_settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ The first time you run the CLI, it will guide you through configuring your LLM s
 openhands
 ```
 
+
+### Configuration
+
+OpenHands CLI stores configuration under `~/.openhands/` (created on first run):
+
+- `agent_settings.json`: persisted agent settings (including condenser config)
+- `cli_config.json`: CLI/TUI preferences (e.g., critic enabled)
+- `mcp.json`: MCP server configuration
+
+By default, environment variables like `LLM_API_KEY`, `LLM_MODEL`, and `LLM_BASE_URL` are ignored; pass `--override-with-envs` to apply them (not persisted).
+
 ### Running Modes
 
 | Mode | Command | Best For |
@@ -125,7 +136,7 @@ openhands --headless --json -t "Create a Flask app"
 
 ## Documentation
 
-For complete documentation, visit [docs.openhands.dev/openhands/usage/cli]().
+For complete documentation, visit https://docs.openhands.dev/openhands/usage/cli.
 
 ## License
 

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -1,4 +1,4 @@
-# openhands_cli/settings/store.py
+# openhands_cli/stores/agent_store.py
 from __future__ import annotations
 
 import json
@@ -458,10 +458,7 @@ class AgentStore:
 
         Args:
             llm_api_key: The LLM API key to use
-            settings: User settings dictionary containing model and other config
-            base_url: Base URL for the LLM service (defaults to
-                `settings['llm_base_url']`
-            )
+            settings: User settings dictionary (e.g., "llm_model", "llm_base_url")
             default_model: Default model to use if not specified in settings
 
         Returns:


### PR DESCRIPTION
HUMAN:

Fixes #389

@xingyaoww please correct me if wrong, my feeling is that we introduced this behavior in the middle of some condenser bug fixes, in particular one where we made the default `max_size=240` if I recall correctly. So we wanted users to use that, rather than 120 which ran into the bug.

This seemed to me an emergency, it doesn’t seem the right behavior long term though. My condenser is set to 700 or so… 😅

—-

AGENT:

### Summary
Stop recreating the condenser with default values during agent load. Instead, preserve the user-configured `LLMSummarizingCondenser` fields from `agent_settings.json` and only update its `llm` with:
- env var overrides (when enabled)
- runtime metadata (`litellm_extra_body`)

### Why
User settings on disk should not be overwritten by defaults at runtime.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cf942108741f4986b3b7b19e8205e4d3)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix-condenser-defaults-not-overriding
```