### PR TITLE
feat(cli): add --plugin flag for loading plugins

### DIFF
--- a/openhands_cli/argparsers/main_parser.py
+++ b/openhands_cli/argparsers/main_parser.py
@@ -40,6 +40,8 @@ def create_main_parser() -> argparse.ArgumentParser:
                 openhands --resume conversation-id  # Resume conversation
                 openhands --always-approve          # Auto-approve all actions
                 openhands --llm-approve             # LLM-based approval mode
+                openhands --plugin ./my-plugin      # Load a local plugin
+                openhands --plugin github:org/repo  # Load plugin from GitHub
                 openhands cloud -t "Fix bug"        # Create cloud conversation
                 openhands serve                     # Launch GUI server
                 openhands serve --gpu               # Launch with GPU support
@@ -73,6 +75,19 @@ def create_main_parser() -> argparse.ArgumentParser:
         "--file",
         type=str,
         help="Path to a file whose contents will seed the initial conversation",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--plugin",
+        action="append",
+        dest="plugins",
+        metavar="PATH_OR_URL",
+        help=(
+            "Load a plugin from a local path or GitHub URL. "
+            "Can be specified multiple times to load multiple plugins. "
+            "Example: --plugin ./my-plugin or --plugin github:owner/repo"
+        ),
     )
 
     # CLI arguments at top level (default mode)

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -215,6 +215,7 @@ def main() -> None:
                 exit_without_confirmation=args.exit_without_confirmation,
                 headless=args.headless,
                 json_mode=json_mode,
+                plugin_sources=args.plugins,
             )
             console.print("Goodbye! 👋", style=OPENHANDS_THEME.success)
             console.print(

--- a/openhands_cli/locations.py
+++ b/openhands_cli/locations.py
@@ -12,3 +12,6 @@ AGENT_SETTINGS_PATH = "agent_settings.json"
 
 # MCP configuration file (relative to PERSISTENCE_DIR)
 MCP_CONFIG_FILE = "mcp.json"
+
+# Plugin cache directory for storing fetched plugins
+PLUGINS_CACHE_DIR = os.path.join(PERSISTENCE_DIR, "plugins_cache")

--- a/openhands_cli/setup.py
+++ b/openhands_cli/setup.py
@@ -1,19 +1,21 @@
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 from rich.console import Console
 
-from openhands.sdk import Agent, AgentContext, BaseConversation, Conversation, Workspace
+from openhands.sdk import Agent, AgentContext, BaseConversation, Conversation, Plugin, Workspace
 from openhands.sdk.context import Skill
 from openhands.sdk.event.base import Event
+from openhands.sdk.hooks.config import HookConfig
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 
 # Register tools on import
-from openhands_cli.locations import CONVERSATIONS_DIR, WORK_DIR
+from openhands_cli.locations import CONVERSATIONS_DIR, PLUGINS_CACHE_DIR, WORK_DIR
 from openhands_cli.stores import AgentStore
 from openhands_cli.tui.widgets.richlog_visualizer import ConversationVisualizer
 
@@ -22,6 +24,129 @@ class MissingAgentSpec(Exception):
     """Raised when agent specification is not found or invalid."""
 
     pass
+
+
+def load_plugins(plugin_sources: list[str] | None) -> list[Plugin]:
+    """Load plugins from local paths or remote URLs.
+
+    Args:
+        plugin_sources: List of plugin paths or URLs. Supports:
+            - Local paths: ./my-plugin, /absolute/path/to/plugin
+            - GitHub URLs: github:owner/repo, github:owner/repo@ref
+            - Full URLs: https://github.com/owner/repo
+
+    Returns:
+        List of loaded Plugin instances
+    """
+    if not plugin_sources:
+        return []
+
+    console = Console()
+    plugins: list[Plugin] = []
+
+    for source in plugin_sources:
+        try:
+            if source.startswith(("./", "/", "~")) or Path(source).exists():
+                # Local path
+                expanded_path = Path(source).expanduser().resolve()
+                console.print(f"Loading plugin from: {expanded_path}", style="white")
+                plugin = Plugin.load(expanded_path)
+            else:
+                # Remote source (GitHub URL or github: shorthand)
+                console.print(f"Fetching plugin from: {source}", style="white")
+                plugin_path = Plugin.fetch(
+                    source,
+                    cache_dir=Path(PLUGINS_CACHE_DIR),
+                )
+                plugin = Plugin.load(plugin_path)
+
+            plugins.append(plugin)
+            console.print(
+                f"✓ Loaded plugin: {plugin.name} (v{plugin.version})", style="green"
+            )
+        except Exception as e:
+            console.print(f"✗ Failed to load plugin '{source}': {e}", style="red")
+            raise
+
+    return plugins
+
+
+def merge_plugins_into_agent(
+    agent: Agent,
+    plugins: list[Plugin],
+) -> tuple[Agent, HookConfig | None]:
+    """Merge plugin configurations into the agent.
+
+    Args:
+        agent: The base agent configuration
+        plugins: List of plugins to merge
+
+    Returns:
+        Tuple of (updated agent, merged hook config)
+    """
+    if not plugins:
+        return agent, None
+
+    # Collect all skills from plugins
+    all_skills: list[Skill] = []
+    # Collect all MCP servers from plugins
+    all_mcp_servers: dict[str, Any] = {}
+    # Collect all hooks from plugins
+    merged_hooks: HookConfig | None = None
+
+    for plugin in plugins:
+        # Collect skills
+        if plugin.skills:
+            all_skills.extend(plugin.skills)
+
+        # Collect MCP config
+        if plugin.mcp_config:
+            mcp_servers = plugin.mcp_config.get("mcpServers", {})
+            all_mcp_servers.update(mcp_servers)
+
+        # Merge hooks (later plugins override earlier ones)
+        if plugin.hooks:
+            if merged_hooks is None:
+                merged_hooks = plugin.hooks
+            else:
+                # Merge hook configs
+                merged_hooks = HookConfig(
+                    pre_tool_call=merged_hooks.pre_tool_call + plugin.hooks.pre_tool_call
+                    if merged_hooks.pre_tool_call and plugin.hooks.pre_tool_call
+                    else merged_hooks.pre_tool_call or plugin.hooks.pre_tool_call,
+                    post_tool_call=merged_hooks.post_tool_call
+                    + plugin.hooks.post_tool_call
+                    if merged_hooks.post_tool_call and plugin.hooks.post_tool_call
+                    else merged_hooks.post_tool_call or plugin.hooks.post_tool_call,
+                )
+
+    # Update agent with skills
+    if all_skills:
+        if agent.agent_context is not None:
+            existing_skills = list(agent.agent_context.skills)
+            existing_skills.extend(all_skills)
+            agent = agent.model_copy(
+                update={
+                    "agent_context": agent.agent_context.model_copy(
+                        update={"skills": existing_skills}
+                    )
+                }
+            )
+        else:
+            agent = agent.model_copy(
+                update={"agent_context": AgentContext(skills=all_skills)}
+            )
+
+    # Update agent with MCP servers
+    if all_mcp_servers:
+        mcp_config: dict[str, Any] = agent.mcp_config or {}
+        existing_servers: dict[str, dict[str, Any]] = mcp_config.get("mcpServers", {})
+        existing_servers.update(all_mcp_servers)
+        agent = agent.model_copy(
+            update={"mcp_config": {"mcpServers": existing_servers}}
+        )
+
+    return agent, merged_hooks
 
 
 def load_agent_specs(
@@ -83,6 +208,7 @@ def setup_conversation(
     confirmation_policy: ConfirmationPolicyBase,
     visualizer: ConversationVisualizer | None = None,
     event_callback: Callable[[Event], None] | None = None,
+    plugin_sources: list[str] | None = None,
 ) -> BaseConversation:
     """
     Setup the conversation with agent.
@@ -93,6 +219,7 @@ def setup_conversation(
         confirmation_policy: Confirmation policy to use.
         visualizer: Optional visualizer to use. If None, a default will be used
         event_callback: Optional callback function to handle events (e.g., JSON output)
+        plugin_sources: Optional list of plugin paths or URLs to load
 
     Raises:
         MissingAgentSpec: If agent specification is not found or invalid.
@@ -100,7 +227,13 @@ def setup_conversation(
     console = Console()
     console.print("Initializing agent...", style="white")
 
+    # Load plugins if specified
+    plugins = load_plugins(plugin_sources)
+
     agent = load_agent_specs(str(conversation_id))
+
+    # Merge plugin configurations into agent
+    agent, hook_config = merge_plugins_into_agent(agent, plugins)
 
     # Prepare callbacks list
     callbacks = [event_callback] if event_callback else None
@@ -114,11 +247,14 @@ def setup_conversation(
         conversation_id=conversation_id,
         visualizer=visualizer,
         callbacks=callbacks,
+        hook_config=hook_config,
     )
 
     conversation.set_security_analyzer(LLMSecurityAnalyzer())
     conversation.set_confirmation_policy(confirmation_policy)
 
     console.print(f"✓ Agent initialized with model: {agent.llm.model}", style="green")
+    if plugins:
+        console.print(f"✓ Loaded {len(plugins)} plugin(s)", style="green")
 
     return conversation

--- a/openhands_cli/tui/core/conversation_runner.py
+++ b/openhands_cli/tui/core/conversation_runner.py
@@ -42,6 +42,7 @@ class ConversationRunner:
         visualizer: ConversationVisualizer,
         initial_confirmation_policy: ConfirmationPolicyBase | None = None,
         event_callback: Callable[[Event], None] | None = None,
+        plugin_sources: list[str] | None = None,
     ):
         """Initialize the conversation runner.
 
@@ -52,6 +53,7 @@ class ConversationRunner:
             visualizer: Optional visualizer for output display.
             initial_confirmation_policy: Initial confirmation policy to use.
                                         If None, defaults to AlwaysConfirm.
+            plugin_sources: Optional list of plugin paths or URLs to load.
         """
         starting_confirmation_policy = initial_confirmation_policy or AlwaysConfirm()
         self.visualizer = visualizer
@@ -60,6 +62,7 @@ class ConversationRunner:
             confirmation_policy=starting_confirmation_policy,
             visualizer=visualizer,
             event_callback=event_callback,
+            plugin_sources=plugin_sources,
         )
 
         self._running = False

--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -94,6 +94,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
         initial_confirmation_policy: ConfirmationPolicyBase | None = None,
         headless_mode: bool = False,
         json_mode: bool = False,
+        plugin_sources: list[str] | None = None,
         **kwargs,
     ):
         """Initialize the app with custom OpenHands theme.
@@ -107,6 +108,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
                                        If None, defaults to AlwaysConfirm.
             headless_mode: If True, run in headless mode.
             json_mode: If True, enable JSON output mode.
+            plugin_sources: Optional list of plugin paths or URLs to load.
         """
         super().__init__(**kwargs)
 
@@ -121,6 +123,9 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
 
         # Store JSON mode setting
         self.json_mode = json_mode
+
+        # Store plugin sources for loading when conversation starts
+        self.plugin_sources = plugin_sources
 
         # Store resume conversation ID
         self.conversation_id = (
@@ -438,6 +443,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
             conversation_visualizer,
             self.initial_confirmation_policy,
             event_callback,
+            plugin_sources=self.plugin_sources,
         )
 
         return runner
@@ -891,6 +897,7 @@ def main(
     exit_without_confirmation: bool = False,
     headless: bool = False,
     json_mode: bool = False,
+    plugin_sources: list[str] | None = None,
 ):
     """Run the textual app.
 
@@ -902,6 +909,7 @@ def main(
         exit_without_confirmation: If True, exit without showing confirmation dialog.
         headless: If True, run in headless mode (no UI output, auto-approve actions).
         json_mode: If True, enable JSON output mode (implies headless).
+        plugin_sources: Optional list of plugin paths or URLs to load.
     """
     # Determine initial confirmation policy from CLI arguments
     # If headless mode is enabled, always use NeverConfirm (auto-approve all actions)
@@ -920,6 +928,7 @@ def main(
         initial_confirmation_policy=initial_confirmation_policy,
         headless_mode=headless,
         json_mode=json_mode,
+        plugin_sources=plugin_sources,
     )
     app.run(headless=headless)
 


### PR DESCRIPTION
Issue: #409
## Summary
- Add `-p/--plugin` CLI flag for loading plugins from local paths or GitHub URLs
- Plugins provide skills, hooks, and MCP configurations merged into the agent
- Supports multiple plugins via repeated `--plugin` flags

## Changes
- `argparsers/main_parser.py` - Add `-p/--plugin` argument
- `locations.py` - Add `PLUGINS_CACHE_DIR` constant
- `setup.py` - Add `load_plugins()`, `merge_plugins_into_agent()`
- `tui/core/conversation_runner.py` - Add `plugin_sources` parameter
- `tui/textual_app.py` - Thread `plugin_sources` through app
- `entrypoint.py` - Pass `args.plugins` to textual_main

## Test plan
- [x] `uv run pytest` - All 1144 tests pass
- [x] Verified `openhands --help` shows `-p/--plugin` flag
- [ ] Manual test with local plugin (requires plugin fixture)

## Test Results
uv run pytest
================= 1144 passed, 3 warnings in 109.46s (0:01:49) =================

## CLI Help Output
```
$ openhands --help
usage: openhands [-h] [--version] [-t TASK] [-f FILE] [-p PATH_OR_URL] [--resume [RESUME]] [--last]
                 [--headless] [--json] [--always-approve | --llm-approve] [--exit-without-confirmation]
                 [--override-with-envs]
                 {acp,serve,web,mcp,cloud,login,logout,view} ...

OpenHands CLI - Terminal User Interface for OpenHands AI Agent

positional arguments:
  {acp,serve,web,mcp,cloud,login,logout,view}
                        Additional commands
    acp                 Start OpenHands as an Agent Client Protocol (ACP) agent (e.g., Toad CLI, Zed IDE)
    serve               Launch the OpenHands GUI server using Docker (web interface)
    web                 Launch the OpenHands CLI as a web application (browser interface)
    mcp                 Manage Model Context Protocol (MCP) server configurations
    cloud               Create a new conversation in OpenHands Cloud
    login               Authenticate with OpenHands Cloud using OAuth 2.0 Device Flow
    logout              Log out from OpenHands Cloud
    view                View the trajectory of an existing conversation

options:
  -h, --help            show this help message and exit
  --version, -v         Show the version number and exit
  -t TASK, --task TASK  Initial task text to seed the conversation with
  -f FILE, --file FILE  Path to a file whose contents will seed the initial conversation
  -p PATH_OR_URL, --plugin PATH_OR_URL
                        Load a plugin from a local path or GitHub URL. Can be specified multiple times to
                        load multiple plugins. Example: --plugin ./my-plugin or --plugin
                        github:owner/repo
  --resume [RESUME]     Conversation ID to resume. If no ID provided, shows list of recent conversations
  --last                Resume the most recent conversation (use with --resume)
  --headless            Run in headless mode (no UI output, auto-approve actions). Requires --task or
                        --file.
  --json                Enable JSON output mode for headless operation. Streams JSONL event outputs to
                        terminal. Must be used with --headless.
  --always-approve      Auto-approve all actions without asking for confirmation
  --llm-approve         Enable LLM-based security analyzer (only confirm LLM-predicted high-risk actions)
  --exit-without-confirmation
                        Exit the application without showing confirmation dialog
  --override-with-envs  Override LLM settings with environment variables (LLM_API_KEY, LLM_BASE_URL,
                        LLM_MODEL). By default, environment variables are ignored.

            By default, OpenHands runs in textual UI mode (terminal interface)
            with 'always-ask' confirmation mode, where all agent actions
            require user confirmation.

            Use 'serve' subcommand to launch the GUI server instead.

            Examples:
                openhands                           # Start textual UI mode
                openhands --headless                # Start textual UI in headless mode
                openhands --headless --json -t "Fix bug"  # Headless with JSON output
                openhands --resume conversation-id  # Resume conversation
                openhands --always-approve          # Auto-approve all actions
                openhands --llm-approve             # LLM-based approval mode
                openhands --plugin ./my-plugin      # Load a local plugin
                openhands --plugin github:org/repo  # Load plugin from GitHub
                openhands cloud -t "Fix bug"        # Create cloud conversation
                openhands serve                     # Launch GUI server
                openhands serve --gpu               # Launch with GPU support
                openhands web                       # Launch CLI as web app
                openhands web --port 8080           # Launch web app on custom port
                openhands acp                       # Agent-Client Protocol
                                                      server (e.g., Toad CLI, Zed IDE)
                openhands login                     # Authenticate with OpenHands Cloud
                openhands logout                    # Log out from OpenHands Cloud

```