### PR TITLE
Remove spinner in headless mode, output status messages once

### DIFF
--- a/openhands_cli/tui/core/conversation_runner.py
+++ b/openhands_cli/tui/core/conversation_runner.py
@@ -159,9 +159,9 @@ class ConversationRunner:
                 self._run_with_confirmation()
             elif headless:
                 console = Console()
-                with console.status("Agent is working") as status:
-                    self.conversation.run()
-                    status.update("Agent finished")
+                console.print("Agent is working")
+                self.conversation.run()
+                console.print("Agent finished")
             else:
                 self.conversation.run()
 

--- a/tests/tui/test_headless_mode.py
+++ b/tests/tui/test_headless_mode.py
@@ -344,6 +344,46 @@ class TestPrintConversationSummary:
 # ---------------------------------------------------------------------------
 
 
+class TestHeadlessRunnerOutput:
+    """Tests for headless mode output without spinner."""
+
+    def test_headless_mode_prints_status_without_spinner(self):
+        """Test that headless mode prints status messages without spinner."""
+        from openhands_cli.tui.core.conversation_runner import ConversationRunner
+
+        mock_conversation = Mock()
+        mock_conversation.send_message = Mock()
+        mock_conversation.run = Mock()
+
+        runner = ConversationRunner(
+            conversation_id=uuid.uuid4(),
+            running_state_callback=Mock(),
+            confirmation_callback=Mock(),
+            notification_callback=Mock(),
+            visualizer=Mock(),
+        )
+        runner.conversation = mock_conversation
+        runner._confirmation_mode_active = False
+
+        message = Mock()
+
+        with patch(
+            "openhands_cli.tui.core.conversation_runner.Console"
+        ) as mock_console_cls:
+            mock_console = MagicMock()
+            mock_console_cls.return_value = mock_console
+
+            runner._run_conversation_sync(message, headless=True)
+
+            # Verify console.print was called with the expected messages
+            print_calls = [call[0][0] for call in mock_console.print.call_args_list]
+            assert "Agent is working" in print_calls
+            assert "Agent finished" in print_calls
+
+            # Verify console.status was NOT called (no spinner)
+            mock_console.status.assert_not_called()
+
+
 class TestConversationSummary:
     """Tests for ConversationRunner.get_conversation_summary itself."""
 


### PR DESCRIPTION
## Summary

This PR removes the spinner animation in headless mode and replaces it with simple print statements for "Agent is working" and "Agent finished". This makes the output cleaner and easier to parse when using `--headless --json` mode.

## Changes

- Modified `openhands_cli/tui/core/conversation_runner.py` to use `console.print()` instead of `console.status()` in headless mode
- Added test `test_headless_mode_prints_status_without_spinner` to verify the new behavior

## Before

```
  "sender": null,
  "source": "agent",
  "timestamp": "2026-01-08T05:05:48.407745"
⠧ Agent is working
}
⠧ Agent is working
⠧ Agent finished
```

## After

```
Agent is working
  "sender": null,
  "source": "agent",
  "timestamp": "2026-01-08T05:05:48.407745"
}
Agent finished
```

Fixes #317

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9681fc191eb44436ad772b2762a7b9d2)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/remove-spinner-headless-mode
```