### PR TITLE
cli: add --yolo as alias for --always-approve

### DIFF
--- a/openhands_cli/argparsers/util.py
+++ b/openhands_cli/argparsers/util.py
@@ -11,6 +11,7 @@ def add_confirmation_mode_args(
     """
     parser_or_group.add_argument(
         "--always-approve",
+        "--yolo",
         action="store_true",
         help="Auto-approve all actions without asking for confirmation",
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,6 +135,20 @@ class TestMainEntryPoint:
         assert kwargs["queued_inputs"] is None
 
     @patch("openhands_cli.tui.textual_app.main")
+    @patch("sys.argv", ["openhands", "--yolo"])
+    def test_main_with_yolo_argument(self, mock_textual_main: MagicMock) -> None:
+        """Test that main() passes always_approve=True with --yolo."""
+        mock_textual_main.side_effect = KeyboardInterrupt()
+
+        main()
+
+        mock_textual_main.assert_called_once()
+        kwargs = mock_textual_main.call_args.kwargs
+        assert kwargs["resume_conversation_id"] is None
+        assert kwargs["always_approve"] is True
+        assert kwargs["queued_inputs"] is None
+
+    @patch("openhands_cli.tui.textual_app.main")
     @patch("sys.argv", ["openhands", "--llm-approve"])
     def test_main_with_llm_approve_argument(self, mock_textual_main: MagicMock) -> None:
         """Test that main() passes llm_approve=True with --llm-approve."""
@@ -158,6 +172,7 @@ class TestMainEntryPoint:
         (["openhands"], None, False, False),
         (["openhands", "--resume", "test-id"], "test-id", False, False),
         (["openhands", "--always-approve"], None, True, False),
+        (["openhands", "--yolo"], None, True, False),
         (["openhands", "--llm-approve"], None, False, True),
         (
             ["openhands", "--resume", "test-id", "--always-approve"],


### PR DESCRIPTION
HUMAN: the agent confirmed in front of me that it can run the CLI with `--yolo` interactively and the other agent doesn't get confirmation prompt; conversely without `--yolo` it did.

---

Fixes #227.

## Summary
- Add `--yolo` as an alias for the existing `--always-approve` confirmation mode.
- Add/extend CLI tests to ensure `--yolo` maps to `always_approve=True`.

## Testing
- `pre-commit run -a`
- `pytest -q tests/test_main.py::TestMainEntryPoint::test_main_with_yolo_argument tests/test_main.py::test_main_cli_calls_textual_main`


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/41a8ec150dcb4987927377659d72b114)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/add-yolo-flag
```