### PR TITLE
Update SDK to commit with auto-load hooks from working directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,8 @@ pythonVersion = "3.12"
 useLibraryCodeForTypes = true
 typeCheckingMode = "standard"
 
-# USE EXACT COMMIT FROM AGENT-SDK (PR #1368 - Add condense method to conversation class)
-
-# [tool.uv.sources]
-# openhands-sdk = { git = "https://github.com/OpenHands/software-agent-sdk.git", subdirectory = "openhands-sdk", rev = "c76e5bd220ea9eb95a9d351313bdb4e533c9da6e" }
-# openhands-tools = { git = "https://github.com/OpenHands/software-agent-sdk.git", subdirectory = "openhands-tools", rev = "c76e5bd220ea9eb95a9d351313bdb4e533c9da6e" }
+# USE EXACT COMMIT FROM AGENT-SDK (PR #1878 - Add stop hook for CI validation + auto-load hooks)
+[tool.uv.sources]
+openhands-sdk = { git = "https://github.com/OpenHands/software-agent-sdk.git", subdirectory = "openhands-sdk", rev = "41b8bf959feaaa30f30dfc4713af27b8478ff419" }
+openhands-tools = { git = "https://github.com/OpenHands/software-agent-sdk.git", subdirectory = "openhands-tools", rev = "41b8bf959feaaa30f30dfc4713af27b8478ff419" }
+openhands-workspace = { git = "https://github.com/OpenHands/software-agent-sdk.git", subdirectory = "openhands-workspace", rev = "41b8bf959feaaa30f30dfc4713af27b8478ff419" }


### PR DESCRIPTION
## Summary

This PR updates the SDK dependency to point to software-agent-sdk commit `41b8bf95` which includes:

1. **Auto-load hooks from working directory** - When `LocalConversation._ensure_plugins_loaded()` is called and no explicit `hook_config` is provided (and no plugins with hooks are loaded), the SDK now automatically loads hooks from `.openhands/hooks.json` in the working directory.

2. **Stop hook for pre-commit, pytest, and CI validation** - The SDK PR #1878 adds project-level hooks that validate code quality and CI status before allowing the agent to finish.

## Why This Change

Previously, the OpenHands CLI did not auto-load hooks from `.openhands/hooks.json` in the working directory. This meant that project-level hooks (like the stop hook added in SDK PR #1878) would not be triggered when running the CLI.

With this change, the SDK automatically discovers and loads hooks from the working directory, enabling project-level hooks to work without requiring explicit configuration in the CLI.

## Related PRs

- OpenHands/software-agent-sdk#1878 - Add stop hook for pre-commit, pytest, and CI validation

## Testing

This PR should be tested by running the CLI on the SDK PR to verify that the stop hooks are triggered correctly.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/36f05f3bbc4e4d008f3c20e333926a66)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@update-sdk-for-auto-hook-loading
```