### PR TITLE
fix: pass Laminar API key as action input in PR review workflow

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -37,8 +37,6 @@ jobs:
             group: pr-review-${{ github.event.pull_request.number }}
             cancel-in-progress: true
         runs-on: ubuntu-24.04
-        env:
-            LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_SKILLS_API_KEY }}
         steps:
             - name: Run PR Review
               uses: OpenHands/software-agent-sdk/.github/actions/pr-review@main
@@ -49,3 +47,4 @@ jobs:
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Fix the PR review workflow to properly pass the Laminar API key to the pr-review action.

## Problem

The workflow was setting `LMNR_PROJECT_API_KEY` as a job-level environment variable:

```yaml
env:
    LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_SKILLS_API_KEY }}
```

However, the `pr-review` action expects the API key to be passed as the `lmnr-api-key` input parameter, not as an environment variable at the job level.

## Solution

Pass the secret directly as an action input:

```yaml
with:
    lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}
```

This ensures the API key is properly forwarded to the underlying script via the action's input handling, which sets `LMNR_PROJECT_API_KEY` environment variable in the step's context.

## Related

- Related SDK fix: https://github.com/OpenHands/software-agent-sdk/pull/1979

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix-pr-review-laminar-api-key
```