### PR TITLE
feat: distinguish hook rejections from user rejections in TUI and ACP

### DIFF
--- a/tests/acp/events/test_shared_event_handler.py
+++ b/tests/acp/events/test_shared_event_handler.py
@@ -1,0 +1,60 @@
+"""Tests for ACP shared event handler hook rejection functionality."""
+
+import pytest
+
+from openhands.sdk.event import AgentErrorEvent, UserRejectObservation
+from openhands_cli.acp_impl.events.shared_event_handler import _is_hook_rejection
+
+
+class TestACPHookRejectionDetection:
+    """Tests for hook rejection detection in ACP shared event handler."""
+
+    def test_is_hook_rejection_detects_blocked_by_hook(self):
+        """Test that 'blocked by hook' pattern is detected."""
+        event = UserRejectObservation(
+            tool_name="terminal",
+            tool_call_id="call_1",
+            action_id="action_1",
+            rejection_reason="Blocked by hook",
+        )
+        assert _is_hook_rejection(event) is True
+
+    def test_is_hook_rejection_detects_hook_blocked(self):
+        """Test that 'hook blocked' pattern is detected."""
+        event = UserRejectObservation(
+            tool_name="terminal",
+            tool_call_id="call_1",
+            action_id="action_1",
+            rejection_reason="This action was hook blocked for security",
+        )
+        assert _is_hook_rejection(event) is True
+
+    def test_is_hook_rejection_case_insensitive(self):
+        """Test that hook detection is case insensitive."""
+        event = UserRejectObservation(
+            tool_name="terminal",
+            tool_call_id="call_1",
+            action_id="action_1",
+            rejection_reason="BLOCKED BY HOOK",
+        )
+        assert _is_hook_rejection(event) is True
+
+    def test_is_hook_rejection_returns_false_for_user_rejection(self):
+        """Test that user rejections are not detected as hook rejections."""
+        event = UserRejectObservation(
+            tool_name="terminal",
+            tool_call_id="call_1",
+            action_id="action_1",
+            rejection_reason="User rejected the action",
+        )
+        assert _is_hook_rejection(event) is False
+
+    def test_is_hook_rejection_returns_false_for_custom_reason(self):
+        """Test that custom rejection reasons are not detected as hooks."""
+        event = UserRejectObservation(
+            tool_name="terminal",
+            tool_call_id="call_1",
+            action_id="action_1",
+            rejection_reason="I don't want to run this dangerous command",
+        )
+        assert _is_hook_rejection(event) is False


### PR DESCRIPTION
## Summary

This PR improves the visibility of hook response events by distinguishing between hook-originated rejections and user-initiated rejections in both the TUI and ACP.

## Background

The OpenHands SDK hooks system allows hooks to block actions via `PreToolUse` hooks. When a hook blocks an action, the reason is stored and later emitted as a `UserRejectObservation` event. Previously, both hook rejections and user rejections during confirmation mode appeared identically as "User Rejected Action", which was confusing.

## Changes

### TUI (`openhands_cli/tui/widgets/richlog_visualizer.py`)
- Added `_is_hook_rejection()` helper function to detect hook-originated rejections based on patterns like "blocked by hook", "hook rejected", "hook blocked", "hook denied"
- Added `_get_rejection_title()` function that returns "Hook Blocked Action" for hook rejections vs "User Rejected Action" for user rejections  
- Updated the status icon to show `⚡ ✗` (hook + error icons) for hook rejections instead of just `✗`
- Updated the title display to show the appropriate rejection type

### ACP (`openhands_cli/acp_impl/events/shared_event_handler.py`)
- Added `_is_hook_rejection()` helper function with the same detection logic
- Updated `handle_user_reject_or_agent_error()` to prepend `**⚡ Hook Blocked Action**` header for hook rejections

### Tests Added
- 9 new tests in `tests/tui/widgets/test_richlog_visualizer.py::TestHookRejectionDetection`
- 5 new tests in `tests/acp/events/test_shared_event_handler.py::TestACPHookRejectionDetection`

## Visual Example

**Before**: A hook blocking an action would show:
```
User Rejected Action ✗
```

**After**: The same hook rejection now shows:
```
Hook Blocked Action ⚡ ✗
```

## Verification

- [x] `make lint` passed
- [x] `make test` passed (1181 tests)
- No TUI changes that require snapshot updates (only text content changes)

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/hook-response-logging
```