### PR TITLE
feat: add /agents command to view available and active sub-agents

### DIFF
--- a/openhands_cli/tui/core/commands.py
+++ b/openhands_cli/tui/core/commands.py
@@ -188,5 +188,15 @@ def _get_active_sub_agents(
             return []
 
         return list(sub_agents.keys())
-    except Exception:
+    except AttributeError as e:
+        # Expected: conversation/agent/tools_map access on objects that don't have these attrs
+        import logging
+
+        logging.debug(f"Failed to get active sub-agents (expected if no conversation): {e}")
+        return []
+    except Exception as e:
+        # Unexpected error - log it so we know something is wrong
+        import logging
+
+        logging.warning(f"Unexpected error getting active sub-agents: {e}", exc_info=True)
         return []

--- a/openhands_cli/tui/core/commands.py
+++ b/openhands_cli/tui/core/commands.py
@@ -151,9 +151,8 @@ def show_agents(
     lines.append(f"\n[bold {secondary}]Active Sub-Agents[/bold {secondary}]")
     active_agents = _get_active_sub_agents(runner)
     if active_agents:
-        for agent_id, agent_type in active_agents:
-            type_label = f" [{secondary}]({agent_type})[/{secondary}]" if agent_type else ""
-            lines.append(f"  - {agent_id}{type_label}")
+        for agent_id in active_agents:
+            lines.append(f"  - {agent_id}")
     else:
         lines.append("  [dim]No active sub-agents in this session.[/dim]")
 
@@ -164,11 +163,11 @@ def show_agents(
 
 def _get_active_sub_agents(
     runner: ConversationRunner | None,
-) -> list[tuple[str, str]]:
+) -> list[str]:
     """Get active sub-agents from the conversation runner's delegate executor.
 
     Returns:
-        List of (agent_id, agent_type) tuples, or empty list if unavailable.
+        List of agent IDs, or empty list if unavailable.
     """
     if runner is None or runner.conversation is None:
         return []
@@ -184,9 +183,6 @@ def _get_active_sub_agents(
         if not sub_agents:
             return []
 
-        results = []
-        for agent_id in sub_agents:
-            results.append((agent_id, ""))
-        return results
+        return list(sub_agents.keys())
     except Exception:
         return []

--- a/openhands_cli/tui/textual_app.tcss
+++ b/openhands_cli/tui/textual_app.tcss
@@ -39,7 +39,7 @@ Screen {
     color: $primary;
 }
 
-.help-message, .error-message, .status-message {
+.help-message, .error-message, .status-message, .agents-message {
     padding: 0 1;
     background: $background;
     color: $foreground;

--- a/openhands_cli/tui/widgets/input_area.py
+++ b/openhands_cli/tui/widgets/input_area.py
@@ -28,7 +28,7 @@ from textual import on
 from textual.containers import Container
 from textual.reactive import var
 
-from openhands_cli.tui.core.commands import show_help, show_skills
+from openhands_cli.tui.core.commands import show_agents, show_help, show_skills
 from openhands_cli.tui.messages import SlashCommandSubmitted
 
 
@@ -86,6 +86,8 @@ class InputAreaContainer(Container):
                 self._command_condense()
             case "skills":
                 self._command_skills()
+            case "agents":
+                self._command_agents()
             case "feedback":
                 self._command_feedback()
             case "exit":
@@ -151,6 +153,13 @@ class InputAreaContainer(Container):
         if self.loaded_resources:
             show_skills(self.scroll_view, self.loaded_resources)
             self.scroll_view.scroll_end(animate=False)
+
+    def _command_agents(self) -> None:
+        """Handle the /agents command to display available and active sub-agents."""
+        app = cast("OpenHandsApp", self.app)
+        runner = app.conversation_manager.current_runner
+        show_agents(self.scroll_view, runner)
+        self.scroll_view.scroll_end(animate=False)
 
     def _command_feedback(self) -> None:
         """Handle the /feedback command to open feedback form in browser."""

--- a/tests/tui/test_commands.py
+++ b/tests/tui/test_commands.py
@@ -12,7 +12,12 @@ from textual_autocomplete import DropdownItem
 from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands_cli.conversations.models import ConversationMetadata
 from openhands_cli.conversations.store.local import LocalFileStore
-from openhands_cli.tui.core.commands import COMMANDS, is_valid_command, show_help
+from openhands_cli.tui.core.commands import (
+    COMMANDS,
+    is_valid_command,
+    show_agents,
+    show_help,
+)
 from openhands_cli.tui.modals import SettingsScreen
 from openhands_cli.tui.modals.confirmation_modal import (
     ConfirmationSettingsModal,
@@ -29,7 +34,7 @@ class TestCommands:
     def test_commands_list_structure(self):
         """Test that COMMANDS list has correct structure."""
         assert isinstance(COMMANDS, list)
-        assert len(COMMANDS) == 8
+        assert len(COMMANDS) == 9
 
         # Check that all items are DropdownItems
         for command in COMMANDS:
@@ -47,6 +52,7 @@ class TestCommands:
             ("/confirm", "Configure confirmation settings"),
             ("/condense", "Condense conversation history"),
             ("/skills", "View loaded skills, hooks, and MCPs"),
+            ("/agents", "View available and active sub-agents"),
             ("/feedback", "Send anonymous feedback about CLI"),
             ("/exit", "Exit the application"),
         ],
@@ -86,6 +92,7 @@ class TestCommands:
             "/confirm",
             "/condense",
             "/skills",
+            "/agents",
             "/feedback",
             "/exit",
             "Display available commands",
@@ -94,6 +101,7 @@ class TestCommands:
             "Configure confirmation settings",
             "Condense conversation history",
             "View loaded skills, hooks, and MCPs",
+            "View available and active sub-agents",
             "Send anonymous feedback about CLI",
             "Exit the application",
             "Tips:",
@@ -160,6 +168,7 @@ class TestCommands:
             ("/confirm", True),
             ("/condense", True),
             ("/skills", True),
+            ("/agents", True),
             ("/feedback", True),
             ("/exit", True),
             ("/help extra", False),
@@ -182,7 +191,8 @@ class TestCommands:
         assert "/help" in command_names
         assert "/new" in command_names
         assert "/skills" in command_names
-        assert len(COMMANDS) == 8
+        assert "/agents" in command_names
+        assert len(COMMANDS) == 9
 
     def test_all_commands_included_in_help(self):
         """Test that all commands from COMMANDS list are included in help text.
@@ -213,6 +223,105 @@ class TestCommands:
             f"The following commands are defined in COMMANDS but missing from "
             f"help text: {missing_commands}"
         )
+
+
+class TestShowAgents:
+    """Tests for the show_agents display function."""
+
+    def test_show_agents_no_runner(self):
+        """show_agents with no runner should display available types and no active agents."""
+        mock_scroll = mock.MagicMock(spec=VerticalScroll)
+
+        show_agents(mock_scroll, runner=None)
+
+        mock_scroll.mount.assert_called_once()
+        widget = mock_scroll.mount.call_args[0][0]
+        content = widget.content
+
+        assert "Sub-Agents" in content
+        assert "Available Agent Types" in content
+        assert "Active Sub-Agents" in content
+        assert "No active sub-agents" in content
+        # Default agent should always be listed
+        assert "default" in content
+
+    def test_show_agents_with_mock_runner_no_delegate(self):
+        """show_agents with runner but no delegate tool shows no active agents."""
+        mock_scroll = mock.MagicMock(spec=VerticalScroll)
+
+        mock_runner = mock.MagicMock()
+        mock_runner.conversation.agent.tools_map = {}
+
+        show_agents(mock_scroll, runner=mock_runner)
+
+        widget = mock_scroll.mount.call_args[0][0]
+        content = widget.content
+
+        assert "Available Agent Types" in content
+        assert "No active sub-agents" in content
+
+    def test_show_agents_with_active_sub_agents(self):
+        """show_agents with active sub-agents should list them."""
+        mock_scroll = mock.MagicMock(spec=VerticalScroll)
+
+        mock_executor = mock.MagicMock()
+        mock_executor._sub_agents = {
+            "researcher": mock.MagicMock(),
+            "security_expert": mock.MagicMock(),
+        }
+
+        mock_delegate_tool = mock.MagicMock()
+        mock_delegate_tool.executor = mock_executor
+
+        mock_runner = mock.MagicMock()
+        mock_runner.conversation.agent.tools_map = {"delegate": mock_delegate_tool}
+
+        show_agents(mock_scroll, runner=mock_runner)
+
+        widget = mock_scroll.mount.call_args[0][0]
+        content = widget.content
+
+        assert "researcher" in content
+        assert "security_expert" in content
+
+    def test_show_agents_mounts_with_correct_css_class(self):
+        """show_agents should mount widget with agents-message CSS class."""
+        mock_scroll = mock.MagicMock(spec=VerticalScroll)
+
+        show_agents(mock_scroll, runner=None)
+
+        widget = mock_scroll.mount.call_args[0][0]
+        assert "agents-message" in widget.classes
+
+    def test_show_agents_displays_custom_registered_agent(self):
+        """show_agents should display custom agents registered via register_agent."""
+        from openhands.tools.delegate.registration import (
+            _reset_registry_for_tests,
+            register_agent,
+        )
+
+        # Register a custom agent
+        register_agent(
+            name="security_auditor",
+            factory_func=lambda llm: mock.MagicMock(),
+            description="Performs security audits on code",
+        )
+
+        try:
+            mock_scroll = mock.MagicMock(spec=VerticalScroll)
+            show_agents(mock_scroll, runner=None)
+
+            widget = mock_scroll.mount.call_args[0][0]
+            content = widget.content
+
+            # Custom agent should appear in Available Agent Types section
+            assert "security_auditor" in content
+            assert "Performs security audits on code" in content
+            # Default agent should still be listed
+            assert "default" in content
+        finally:
+            # Clean up the registry to avoid cross-test contamination
+            _reset_registry_for_tests()
 
 
 class TestOpenHandsAppCommands:
@@ -810,3 +919,30 @@ class TestOpenHandsAppCommands:
 
             top_screen = oh_app.screen_stack[-1]
             assert isinstance(top_screen, SwitchConversationModal)
+
+    @pytest.mark.asyncio
+    async def test_agents_command_displays_agents(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`/agents` should call show_agents and display agent information."""
+        monkeypatch.setattr(
+            SettingsScreen,
+            "is_initial_setup_required",
+            lambda env_overrides_enabled=False: False,
+        )
+
+        app = OpenHandsApp(exit_confirmation=False)
+
+        async with app.run_test() as pilot:
+            oh_app = cast(OpenHandsApp, pilot.app)
+
+            with mock.patch(
+                "openhands_cli.tui.widgets.input_area.show_agents"
+            ) as mock_show:
+                oh_app.conversation_state.input_area._command_agents()
+
+                mock_show.assert_called_once()
+                # First arg is scroll_view, second is runner
+                call_args = mock_show.call_args
+                assert call_args[0][0] is oh_app.conversation_state.input_area.scroll_view

--- a/tests/tui/test_commands.py
+++ b/tests/tui/test_commands.py
@@ -261,13 +261,21 @@ class TestShowAgents:
         assert "No active sub-agents" in content
 
     def test_show_agents_with_active_sub_agents(self):
-        """show_agents with active sub-agents should list them."""
+        """show_agents with active sub-agents should list them.
+
+        Note: _sub_agents is dict[str, LocalConversation] in reality, but since
+        _get_active_sub_agents() only calls .keys(), we just need a dict with
+        the right keys. This test verifies the display logic, not the conversation
+        objects themselves.
+        """
         mock_scroll = mock.MagicMock(spec=VerticalScroll)
 
+        # Real structure: dict[str, LocalConversation]
+        # We only need dict keys for this test since _get_active_sub_agents() calls .keys()
         mock_executor = mock.MagicMock()
         mock_executor._sub_agents = {
-            "researcher": mock.MagicMock(),
-            "security_expert": mock.MagicMock(),
+            "researcher_1": None,  # Explicit None since we don't use the values
+            "security_expert_1": None,
         }
 
         mock_delegate_tool = mock.MagicMock()
@@ -281,8 +289,8 @@ class TestShowAgents:
         widget = mock_scroll.mount.call_args[0][0]
         content = widget.content
 
-        assert "researcher" in content
-        assert "security_expert" in content
+        assert "researcher_1" in content
+        assert "security_expert_1" in content
 
     def test_show_agents_mounts_with_correct_css_class(self):
         """show_agents should mount widget with agents-message CSS class."""


### PR DESCRIPTION
## Summary
- Add `/agents` slash command that displays available agent types from the SDK registry and active sub-agents in the current conversation
- Phase 1+2 of #492. Phase 3 (`@agent-name` invocation) will be a separate PR

## Changes
- `openhands_cli/tui/core/commands.py` — Add `show_agents()`, `_get_active_sub_agents()`, COMMANDS entry, help text
- `openhands_cli/tui/widgets/input_area.py` — Add `case "agents"` routing and `_command_agents()` handler
- `openhands_cli/tui/textual_app.tcss` — Add `.agents-message` CSS class
- `tests/tui/test_commands.py` — 6 new tests (unit + integration), updated command counts

## Test plan
- [x] 74 command tests pass
- [x] 477 TUI tests pass
- [x] 42 snapshot tests pass
- [x] Manual test: `/agents` displays default agent and custom registered agents