### PR TITLE
Settings: enable memory condensation by default in basic and advanced modes

### DIFF
--- a/openhands_cli/tui/modals/settings/components/settings_tab.py
+++ b/openhands_cli/tui/modals/settings/components/settings_tab.py
@@ -101,7 +101,7 @@ class SettingsTab(Container):
                     yield Label("Memory Condensation:", classes="form_label")
                     yield Select(
                         [("Enabled", True), ("Disabled", False)],
-                        value=False,
+                        value=True,
                         id="memory_condensation_select",
                         classes="form_select",
                         disabled=True,  # Disabled until API key is entered

--- a/openhands_cli/tui/modals/settings/settings_screen.py
+++ b/openhands_cli/tui/modals/settings/settings_screen.py
@@ -154,7 +154,7 @@ class SettingsScreen(ModalScreen):
         self.mode_select.value = "basic"
         self.provider_select.value = Select.BLANK
         self.model_select.value = Select.BLANK
-        self.memory_select.value = False
+        self.memory_select.value = True
 
     def _load_current_settings(self) -> None:
         """Load current settings into the form."""

--- a/tests/tui/modals/settings/test_settings_tab.py
+++ b/tests/tui/modals/settings/test_settings_tab.py
@@ -67,8 +67,8 @@ class TestSettingsTab:
             # API key disabled until later steps
             assert api_key.disabled is True
 
-            # Memory condensation defaults off + disabled until later steps
-            assert memory.value is False
+            # Memory condensation defaults on + disabled until later steps
+            assert memory.value is True
             assert memory.disabled is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR enables memory condensation (condenser) as the default value in both basic and advanced settings modes, matching the default experience in the old CLI.

## Changes

- Changed default value of `memory_condensation_select` from `False` to `True` in `settings_tab.py`
- Updated `_clear_form()` in `settings_screen.py` to reset memory select to `True` (instead of `False`)
- Updated test to reflect the new default value

## Verification

- All 1170 tests pass ✓
- Linting passes ✓

## Before/After

**Before:** Memory Condensation was disabled by default in both basic and advanced modes.

**After:** Memory Condensation is enabled by default in both basic and advanced modes, matching the old CLI behavior.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@enable-condenser-by-default
```