### PR TITLE
Allow Vertex models in CLI without requiring LLM API key

### DIFF
--- a/tests/tui/modals/settings/test_settings_utils.py
+++ b/tests/tui/modals/settings/test_settings_utils.py
@@ -243,6 +243,40 @@ def test_missing_api_key_errors_when_no_existing_agent() -> None:
     assert "API Key is required" in str(exc.value)
 
 
+def test_vertex_basic_mode_does_not_require_api_key() -> None:
+    """Vertex provider should allow auth via GCP credentials without API key."""
+    data = settings_utils.SettingsFormData(
+        mode="basic",
+        provider="vertex_ai",
+        model="gemini-2.5-pro",
+        custom_model=None,
+        base_url=None,
+        api_key_input=None,
+        memory_condensation_enabled=True,
+    )
+
+    # Should not raise
+    data.resolve_data_fields(existing_agent=None)
+    assert data.api_key_input is None
+
+
+def test_vertex_advanced_mode_does_not_require_api_key() -> None:
+    """Advanced mode should also allow Vertex models with no API key."""
+    data = settings_utils.SettingsFormData(
+        mode="advanced",
+        provider=None,
+        model=None,
+        custom_model="vertex_ai/gemini-2.5-pro",
+        base_url="https://aiplatform.googleapis.com/",
+        api_key_input=None,
+        memory_condensation_enabled=True,
+    )
+
+    # Should not raise
+    data.resolve_data_fields(existing_agent=None)
+    assert data.api_key_input is None
+
+
 def test_save_settings_wraps_errors_into_result(deps: FakeAgentStore) -> None:
     """save_settings should surface resolver errors as success=False."""
     # Invalid: advanced mode with missing custom_model/base_url


### PR DESCRIPTION
## Summary
- allow `vertex_ai` / `vertex_ai_beta` models to be configured in CLI settings without forcing an API key
- allow `--override-with-envs` / headless agent creation for Vertex models without `LLM_API_KEY`
- keep API key requirement for non-Vertex providers/models

## Why
Vertex authentication is handled via GCP credentials (for example `GOOGLE_APPLICATION_CREDENTIALS`, `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION`), so requiring a fake API key in CLI was incorrect and confusing.

## Changes
- `openhands_cli/tui/modals/settings/utils.py`
  - add Vertex provider/model detection
  - make API key validation conditional (skip for Vertex)
- `openhands_cli/stores/agent_store.py`
  - add `model_requires_api_key()` helper
  - relax headless env validation for Vertex models
  - permit agent creation with `api_key=None` for Vertex models
- tests
  - add settings tests for Vertex-without-key behavior
  - add env override/headless tests for Vertex-without-`LLM_API_KEY`

## Validation
- `uv run ruff check openhands_cli/tui/modals/settings/utils.py openhands_cli/stores/agent_store.py tests/tui/modals/settings/test_settings_utils.py tests/stores/test_env_llm_overrides.py`
- `uv run pytest -q tests/tui/modals/settings/test_settings_utils.py tests/stores/test_env_llm_overrides.py`
  - result: `59 passed`

## Notes
This PR addresses CLI-side validation/agent creation behavior. Runtime import errors for Vertex still require the environment to include `google-cloud-aiplatform` (LiteLLM dependency).
