### PR TITLE
fix(acp): send session/update after session/new response

### DIFF
--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -454,6 +454,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             # Schedule available commands notification to be sent after the response.
             # This ensures the client receives the NewSessionResponse (with sessionId)
             # before any session/update notifications, per the ACP spec.
+            # Fire-and-forget: notification failure is non-fatal.
             asyncio.create_task(self.send_available_commands(session_id))
 
             return response


### PR DESCRIPTION
## Summary

Fix ACP protocol ordering issue where `session/update` notification (with available commands) was sent **before** the `session/new` response was returned.

## Problem

IntelliJ's ACP client was getting stuck with a spinner when starting a conversation. The JetBrains team identified the root cause:

> The problem is that openhands agent is sending session/update (with the session id included) BEFORE it responds to original session/new request.

Looking at their logs:
```
OUT: {"id":2,"method":"session/new",...}
IN: {"method":"session/update","params":{"sessionId":"db946c2c-..."}}   ← Notification arrives first
IN: {"id":2,"result":{"sessionId":"db946c2c-..."}}                      ← Response arrives second
```

The client receives a `session/update` notification with a `sessionId` that hasn't been established yet (the `session/new` response hasn't arrived), causing the client to get into a confused state.

## Root Cause

In `base_agent.py`, the `new_session` method was calling `await self.send_available_commands(session_id)` **before** returning the `NewSessionResponse`:

```python
await self.send_available_commands(session_id)  # Sends notification
# ... 
return response  # Response sent after notification
```

## Solution

Use `asyncio.create_task()` to schedule the `send_available_commands` notification to be sent **after** the response is returned:

```python
asyncio.create_task(self.send_available_commands(session_id))  # Scheduled for later
return response  # Response sent first
```

## ACP Spec Reference

The [ACP Slash Commands spec](https://agentclientprotocol.com/protocol/slash-commands) states:

> "**After** creating a session, the Agent **MAY** send a list of available commands"

The word "After" implies the notification should be sent after the session creation is complete (i.e., after the response is sent).

## Testing

- All existing ACP tests pass
- Tested with `pytest tests/acp/test_agent.py -k new_session` (12 tests pass)
- Tested with `pytest tests/acp/test_jsonrpc_integration.py` (5 tests pass)

## Notes

This fix does not affect `load_session`, where the ACP spec explicitly allows streaming notifications before the response (for replaying conversation history).

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/acp-session-new-notification-ordering
```