### PR TITLE
feat: make UI theme configurable via CLI settings

### DIFF
--- a/openhands_cli/stores/cli_settings.py
+++ b/openhands_cli/stores/cli_settings.py
@@ -51,6 +51,7 @@ class CliSettings(BaseModel):
 
     default_cells_expanded: bool = False
     auto_open_plan_panel: bool = True
+    theme: str = "openhands"
     critic: CriticSettings = CriticSettings()
 
     @classmethod

--- a/openhands_cli/tui/modals/settings/components/cli_settings_tab.py
+++ b/openhands_cli/tui/modals/settings/components/cli_settings_tab.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
-from textual.widgets import Label, Static, Switch
+from textual.widgets import Label, Select, Static, Switch
 
 from openhands_cli.stores.cli_settings import CliSettings
 
@@ -42,6 +42,22 @@ class SettingsSwitch(Container):
         yield Static(self._description, classes="form_help switch_help")
 
 
+def _get_theme_options(current_theme: str) -> list[tuple[str, str]]:
+    """Build (label, value) pairs for the theme selector.
+
+    Includes every built-in Textual theme plus the custom ``openhands`` theme.
+    The list is sorted alphabetically with *openhands* always first.
+    """
+    from textual.app import App
+
+    names = set(App().available_themes) | {"openhands"}
+    if current_theme:
+        names.add(current_theme)
+    ordered = sorted(names - {"openhands"})
+    ordered.insert(0, "openhands")
+    return [(name, name) for name in ordered]
+
+
 class CliSettingsTab(Container):
     """CLI Settings tab component containing CLI-specific settings."""
 
@@ -59,6 +75,20 @@ class CliSettingsTab(Container):
         """Compose the CLI settings tab content."""
         with VerticalScroll(id="cli_settings_content"):
             yield Static("CLI Settings", classes="form_section_title")
+
+            with Container(classes="form_group"):
+                yield Label("Theme:", classes="form_label")
+                yield Select(
+                    _get_theme_options(self._initial_settings.theme),
+                    value=self._initial_settings.theme,
+                    id="theme_select",
+                    allow_blank=False,
+                )
+                yield Static(
+                    "Color theme for the terminal UI. "
+                    "Changes take effect on next launch.",
+                    classes="form_help",
+                )
 
             yield SettingsSwitch(
                 label="Default Cells Expanded",
@@ -86,9 +116,11 @@ class CliSettingsTab(Container):
         """Return only the fields this tab manages.
 
         Returns:
-            Dict with 'default_cells_expanded' and 'auto_open_plan_panel' values.
+            Dict with 'theme', 'default_cells_expanded', and
+            'auto_open_plan_panel' values.
         """
         return {
+            "theme": str(self.query_one("#theme_select", Select).value),
             "default_cells_expanded": self.query_one(
                 "#default_cells_expanded_switch", Switch
             ).value,

--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -210,11 +210,13 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
 
         self.plan_panel: PlanSidePanel = PlanSidePanel(self)
 
-        # Register the custom theme
+        # Register the custom theme and apply the user's preference
         self.register_theme(OPENHANDS_THEME)
-
-        # Set the theme as active
-        self.theme = "openhands"
+        self.theme = (
+            cli_settings.theme
+            if cli_settings.theme in self.available_themes
+            else "openhands"
+        )
 
     CSS_PATH = "textual_app.tcss"
 

--- a/tests/tui/modals/settings/test_cli_settings.py
+++ b/tests/tui/modals/settings/test_cli_settings.py
@@ -89,11 +89,16 @@ class TestCliSettings:
         cfg = CliSettings()
         assert cfg.default_cells_expanded is False
         assert cfg.auto_open_plan_panel is True
+        assert cfg.theme == "openhands"
         assert cfg.critic.enable_critic is True
         assert cfg.critic.enable_iterative_refinement is False
         assert cfg.critic.critic_threshold == 0.6
         assert cfg.critic.issue_threshold == 0.75
         assert cfg.critic.max_refinement_iterations == 3
+
+    def test_theme_accepts_string(self):
+        cfg = CliSettings(theme="dracula")
+        assert cfg.theme == "dracula"
 
     @pytest.mark.parametrize("value", [True, False])
     def test_default_cells_expanded_accepts_bool(self, value: bool):
@@ -186,6 +191,7 @@ class TestCliSettings:
         cfg = CliSettings(
             default_cells_expanded=False,
             auto_open_plan_panel=False,
+            theme="dracula",
             critic=CriticSettings(
                 enable_critic=False,
                 enable_iterative_refinement=False,
@@ -202,6 +208,7 @@ class TestCliSettings:
             {
                 "default_cells_expanded": False,
                 "auto_open_plan_panel": False,
+                "theme": "dracula",
                 "critic": {
                     "enable_critic": False,
                     "enable_iterative_refinement": False,

--- a/tests/tui/modals/settings/test_cli_settings_tab.py
+++ b/tests/tui/modals/settings/test_cli_settings_tab.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Switch
+from textual.widgets import Select, Switch
 
 from openhands_cli.stores.cli_settings import CliSettings
 from openhands_cli.tui.modals.settings.components.cli_settings_tab import (
     CliSettingsTab,
+    _get_theme_options,
 )
 
 
@@ -21,6 +22,30 @@ class _TestApp(App):
 
     def compose(self) -> ComposeResult:
         yield CliSettingsTab(initial_settings=self.initial_settings)
+
+
+class TestGetThemeOptions:
+    """Tests for the _get_theme_options helper."""
+
+    def test_openhands_is_first(self):
+        options = _get_theme_options("openhands")
+        assert options[0] == ("openhands", "openhands")
+
+    def test_includes_builtin_themes(self):
+        options = _get_theme_options("openhands")
+        values = [v for _, v in options]
+        assert "dracula" in values
+        assert "textual-dark" in values
+
+    def test_includes_current_theme(self):
+        options = _get_theme_options("my-custom")
+        values = [v for _, v in options]
+        assert "my-custom" in values
+
+    def test_remaining_sorted(self):
+        options = _get_theme_options("openhands")
+        remaining = [v for _, v in options[1:]]
+        assert remaining == sorted(remaining)
 
 
 class TestCliSettingsTab:
@@ -114,6 +139,31 @@ class TestCliSettingsTab:
             assert result["auto_open_plan_panel"] is new_value
 
     @pytest.mark.asyncio
+    async def test_compose_renders_theme_select_with_initial_value(self):
+        """Verify the theme select is rendered with the configured theme."""
+        initial = CliSettings(theme="dracula")
+        app = _TestApp(initial_settings=initial)
+
+        async with app.run_test():
+            tab = app.query_one(CliSettingsTab)
+            select = tab.query_one("#theme_select", Select)
+            assert select.value == "dracula"
+
+    @pytest.mark.asyncio
+    async def test_get_updated_fields_reflects_theme(self):
+        """Verify get_updated_fields() captures theme select state."""
+        initial = CliSettings(theme="openhands")
+        app = _TestApp(initial_settings=initial)
+
+        async with app.run_test():
+            tab = app.query_one(CliSettingsTab)
+            select = tab.query_one("#theme_select", Select)
+            select.value = "dracula"
+
+            result = tab.get_updated_fields()
+            assert result["theme"] == "dracula"
+
+    @pytest.mark.asyncio
     async def test_get_updated_fields_returns_only_managed_fields(self):
         """Verify get_updated_fields() returns only the fields this tab manages."""
         initial = CliSettings(default_cells_expanded=True, auto_open_plan_panel=False)
@@ -123,8 +173,8 @@ class TestCliSettingsTab:
             tab = app.query_one(CliSettingsTab)
             result = tab.get_updated_fields()
 
-            # Should only contain the 2 fields this tab manages
             assert set(result.keys()) == {
+                "theme",
                 "default_cells_expanded",
                 "auto_open_plan_panel",
             }


### PR DESCRIPTION
## Summary

The CLI hardcodes `self.theme = "openhands"` in `OpenHandsApp.__init__`, which unconditionally overrides any theme the user sets. This PR adds a persisted `theme` setting so the user's choice is respected across launches.

## Changes

| File | What changed |
|------|--------------|
| `openhands_cli/stores/cli_settings.py` | Added `theme: str = "openhands"` field to `CliSettings` |
| `openhands_cli/tui/textual_app.py` | Read theme from `CliSettings` with fallback to `"openhands"` when the stored value is not a registered theme |
| `openhands_cli/tui/modals/settings/components/cli_settings_tab.py` | Added a theme `Select` widget listing every built-in Textual theme plus the custom `openhands` theme |
| `tests/tui/modals/settings/test_cli_settings.py` | Added tests for new `theme` default and round-trip serialization |
| `tests/tui/modals/settings/test_cli_settings_tab.py` | Added tests for `_get_theme_options` helper, theme Select rendering, and `get_updated_fields()` |

### How it works

1. `CliSettings.theme` defaults to `"openhands"` — existing users see no change.
2. Users can pick any Textual built-in theme (dracula, catppuccin-mocha, nord, …) or `openhands` from **Settings → CLI Settings → Theme**.
3. The choice is persisted in `~/.openhands/cli_config.json` and applied on next launch.
4. If the stored theme name is invalid (e.g. a removed theme), the app falls back to `"openhands"`.

## Commands run

- `ruff check .` ✅
- `ruff format --check .` ✅
- `pytest --ignore=tests/snapshots --ignore=tests/acp` — 962 passed, 1 pre-existing failure (unrelated permission error)

## PR checklist

- [x] Scope is minimal and focused on one change
- [x] Tests added/updated for behavior changes
- [x] `make lint`
- [x] `make test`
- [ ] `make test-snapshots` — not run; no visual layout changes (only a new Select widget in the settings tab)
- [x] PR description includes what changed, why, and commands run
