### PR TITLE
fix(auth): improve network error messages and add retry resilience during token polling

### DIFF
--- a/openhands_cli/auth/device_flow.py
+++ b/openhands_cli/auth/device_flow.py
@@ -76,7 +76,11 @@ class DeviceFlowClient(BaseHttpClient):
             ) from e
 
     async def poll_for_token(
-        self, device_code: str, interval: int, timeout: float = 600.0
+        self,
+        device_code: str,
+        interval: int,
+        timeout: float = 600.0,
+        max_network_errors: int = 3,
     ) -> DeviceTokenResponse:
         """Poll for the API key after user authorization.
 
@@ -84,6 +88,7 @@ class DeviceFlowClient(BaseHttpClient):
             device_code: The device code from start_device_flow
             interval: Polling interval in seconds
             timeout: Maximum time to wait for authorization in seconds (default: 10 min)
+            max_network_errors: Number of consecutive network errors before giving up
 
         Returns:
             DeviceTokenResponse containing access_token (API key), token_type, etc.
@@ -93,6 +98,7 @@ class DeviceFlowClient(BaseHttpClient):
         """
         data = {"device_code": device_code}
         start_time = time.time()
+        consecutive_network_errors = 0
 
         while time.time() - start_time < timeout:
             try:
@@ -101,8 +107,15 @@ class DeviceFlowClient(BaseHttpClient):
                     form_data=data,
                     raise_for_status=False,
                 )
+                consecutive_network_errors = 0
             except AuthHttpError as e:
-                raise DeviceFlowError(f"Network error during token polling: {e}") from e
+                consecutive_network_errors += 1
+                if consecutive_network_errors >= max_network_errors:
+                    raise DeviceFlowError(
+                        f"Network error during token polling: {e}"
+                    ) from e
+                await asyncio.sleep(interval)
+                continue
 
             if response.status_code == 200:
                 # Success - parse and validate the token response

--- a/openhands_cli/auth/http_client.py
+++ b/openhands_cli/auth/http_client.py
@@ -114,7 +114,8 @@ class BaseHttpClient:
             raise AuthHttpError(f"HTTP {e.response.status_code}: {error_detail}")
 
         except httpx.RequestError as e:
-            raise AuthHttpError(f"Network error: {str(e)}")
+            error_msg = str(e) or type(e).__name__
+            raise AuthHttpError(f"Network error: {error_msg}")
 
     async def get(
         self,

--- a/tests/auth/test_device_flow.py
+++ b/tests/auth/test_device_flow.py
@@ -265,7 +265,7 @@ class TestDeviceFlowClient:
 
     @pytest.mark.asyncio
     async def test_poll_for_token_network_error(self):
-        """Test token polling with network error."""
+        """Test token polling fails after max consecutive network errors."""
         client = DeviceFlowClient("https://api.example.com")
 
         with patch.object(client, "post") as mock_post:
@@ -273,10 +273,42 @@ class TestDeviceFlowClient:
 
             mock_post.side_effect = AuthHttpError("Connection failed")
 
-            with pytest.raises(
-                DeviceFlowError, match="Network error during token polling"
-            ):
-                await client.poll_for_token("device123", 1)
+            with patch("asyncio.sleep"):
+                with pytest.raises(
+                    DeviceFlowError, match="Network error during token polling"
+                ):
+                    await client.poll_for_token("device123", 1)
+
+            # Default max_network_errors=3, so post should be called 3 times
+            assert mock_post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_poll_for_token_transient_network_error_recovers(self):
+        """Test that transient network errors are retried and polling recovers."""
+        client = DeviceFlowClient("https://api.example.com")
+
+        from openhands_cli.auth.http_client import AuthHttpError
+
+        success_response = httpx.Response(status_code=200)
+        success_response._content = json.dumps(
+            {"access_token": "token123", "token_type": "Bearer"}
+        ).encode()
+
+        # Two transient errors followed by success
+        with patch.object(client, "post") as mock_post:
+            mock_post.side_effect = [
+                AuthHttpError("Transient failure 1"),
+                AuthHttpError("Transient failure 2"),
+                success_response,
+            ]
+
+            with patch("asyncio.sleep") as mock_sleep:
+                result = await client.poll_for_token("device123", 5)
+
+                assert isinstance(result, DeviceTokenResponse)
+                assert result.access_token == "token123"
+                # Slept twice (once per transient error before retrying)
+                assert mock_sleep.call_count == 2
 
     @pytest.mark.asyncio
     async def test_poll_for_token_invalid_json_response(self):

--- a/tests/auth/test_http_client.py
+++ b/tests/auth/test_http_client.py
@@ -164,6 +164,19 @@ class TestBaseHttpClient:
                 await client._make_request("GET", "/test")
 
     @pytest.mark.asyncio
+    async def test_make_request_network_error_empty_message(self):
+        """Test that network errors with empty message fall back to exception type name."""
+        client = BaseHttpClient("https://api.example.com")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.request.side_effect = httpx.ConnectError("")
+
+            with pytest.raises(AuthHttpError, match="Network error: ConnectError"):
+                await client._make_request("GET", "/test")
+
+    @pytest.mark.asyncio
     async def test_make_request_no_raise_for_status(self):
         """Test HTTP request without raising for status errors."""
         client = BaseHttpClient("https://api.example.com")


### PR DESCRIPTION
## What changed

Two bugs fixed in the OAuth 2.0 device flow login path, surfaced by a real login failure:

```
Error: Network error during token polling: Network error: 
Authentication failed: Network error during token polling: Network error: 
```

### Bug 1 — Confusing empty error message (`http_client.py`)

`httpx.RequestError` subclasses (e.g. `ConnectError`) can produce an empty `str(e)`. The previous code did:

```python
raise AuthHttpError(f"Network error: {str(e)}")   # → "Network error: "
```

Fix: fall back to the exception class name when the string is empty:

```python
error_msg = str(e) or type(e).__name__
raise AuthHttpError(f"Network error: {error_msg}")  # → "Network error: ConnectError"
```

### Bug 2 — Single network blip kills the entire login (`device_flow.py`)

The polling loop raised immediately on the first `AuthHttpError`, even though the error could be transient (brief connectivity hiccup, DNS blip, etc.). A 10-minute polling window that fails on the very first attempt is not resilient.

Fix: track consecutive network errors and only raise after `max_network_errors` (default: **3**) consecutive failures. Each failed attempt sleeps for `interval` seconds before retrying, consistent with the rest of the polling loop.

## Commands run

```
make lint    # all checks passed
uv run pytest -m "not integration" --ignore=tests/snapshots -q
# 1274 passed
```

## Before / After

**Before:**
```
Waiting for authentication to complete...
Error: Network error during token polling: Network error: 
Authentication failed: Network error during token polling: Network error: 
```

**After (persistent failure):**
```
Waiting for authentication to complete...
Error: Network error during token polling: Network error: ConnectError
Authentication failed: Network error during token polling: Network error: ConnectError
```

**After (transient failure — now recovers silently):**
```
Waiting for authentication to complete...
✓ Authentication successful!
```

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/token-polling-network-error-resilience
```