### PR TITLE
fix: skip terminal compatibility check in headless mode

### DIFF
--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -193,16 +193,19 @@ def main() -> None:
                 sys.exit(1)
 
         else:
-            compat_result = check_terminal_compatibility(console=console)
-            if not compat_result.is_tty:
-                print(
-                    "OpenHands CLI terminal UI may not work correctly in this "
-                    f"environment: {compat_result.reason}"
-                )
-                print(
-                    "To override Rich's detection, you can set TTY_INTERACTIVE=1 "
-                    "(and optionally TTY_COMPATIBLE=1)."
-                )
+            # Only check terminal compatibility when not in headless mode
+            # In headless mode, we don't need an interactive terminal
+            if not args.headless:
+                compat_result = check_terminal_compatibility(console=console)
+                if not compat_result.is_tty:
+                    print(
+                        "OpenHands CLI terminal UI may not work correctly in this "
+                        f"environment: {compat_result.reason}"
+                    )
+                    print(
+                        "To override Rich's detection, you can set TTY_INTERACTIVE=1 "
+                        "(and optionally TTY_COMPATIBLE=1)."
+                    )
             # Handle resume logic (including --last and conversation list)
             resume_id = handle_resume_logic(args)
             if resume_id is None and (args.last or args.resume == ""):


### PR DESCRIPTION
## Summary

When running in headless mode, the CLI was displaying a confusing warning about Rich detecting a non-interactive terminal:

```
OpenHands CLI terminal UI may not work correctly in this environment: Rich detected a non-interactive or unsupported terminal; interactive UI may not render correctly
To override Rich's detection, you can set TTY_INTERACTIVE=1 (and optionally TTY_COMPATIBLE=1).
```

This warning is unnecessary in headless mode since there's no interactive UI to render anyway.

## Changes

- Modified `openhands_cli/entrypoint.py` to wrap the terminal compatibility check in a `if not args.headless:` condition
- The check is now only performed when running in interactive (non-headless) mode

## Verification

- ✅ `make lint` passes
- ✅ `tests/test_terminal_compat.py` tests pass

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@fix/skip-terminal-check-in-headless-mode
```