### PR TITLE
fix: handle IndexError in text selection to prevent session crash

### DIFF
--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -541,8 +541,20 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
         When the user finishes selecting text by releasing the mouse button,
         this method checks if there's selected text and copies it to clipboard.
         """
-        # Get selected text from the screen
-        selected_text = self.screen.get_selected_text()
+        # Textual's Selection.extract() can crash with IndexError when
+        # screen coordinates aren't translated to widget-local coordinates.
+        # See: https://github.com/Textualize/textual/issues/6428
+        # TODO: Remove once upstream fix is merged
+        try:
+            # Get selected text from the screen
+            selected_text = self.screen.get_selected_text()
+        except IndexError:
+            self.notify(
+                "Could not copy selection",
+                title="Selection error",
+                timeout=2,
+            )
+            return
         if not selected_text:
             return
 


### PR DESCRIPTION
Textual's Selection.extract() crashes with IndexError when screen
coordinates aren't translated to widget-local coordinates during
text selection. This adds a defensive try/except to prevent the
crash and notify the user instead of killing their session.

Root cause filed upstream: https://github.com/Textualize/textual/issues/6428

Related: https://github.com/OpenHands/OpenHands-CLI/issues/601