### PR TITLE
acp: extract base agent helpers (#618)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Prefer modern typing syntax (`X | None` over `Optional[X]`) in new code.
 - Pytest discovery: files `test_*.py`, classes `Test*`, functions `test_*`. Use `@pytest.mark.integration` for costly flows.
 - Match test locations to implementation (`tests/` mirrors `openhands_cli/`); add fixtures in `tests/conftest.py` when shared.
 - Run `make test` before PRs; run snapshot/binary tests when relevant to the change.
+- For `openhands_cli/acp_impl/agent/base_agent.py` changes, start with `tests/acp/test_base_agent.py`, then run `tests/acp/test_agent_common.py` to verify shared local/cloud behavior.
 
 ### Binary Tests with Mock LLM
 - Binary tests in `tui_e2e/` can use `mock_llm_server.py` for deterministic testing without real LLM calls.

--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 from uuid import UUID
 
@@ -263,7 +263,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         )
 
     async def _replay_conversation_events(
-        self, session_id: str, events: list[Event], context: str
+        self, session_id: str, events: Sequence[Event], context: str
     ) -> None:
         """Replay stored conversation events to the connected ACP client."""
         if not events:

--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -12,6 +12,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any, cast
+from uuid import UUID
 
 from acp import (
     Agent as ACPAgent,
@@ -45,6 +46,7 @@ from openhands.sdk import (
     BaseConversation,
     Message,
 )
+from openhands.sdk.event.base import Event
 from openhands_cli import __version__
 from openhands_cli.acp_impl.agent.util import AgentType, get_session_mode_state
 from openhands_cli.acp_impl.confirmation import ConfirmationMode
@@ -220,6 +222,107 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             await self._set_confirmation_mode(session_id, new_mode)
 
         return response_text
+
+    def _get_new_session_context(self) -> tuple[str, bool]:
+        """Return the next session ID and whether it resumes a conversation."""
+        if self._resume_conversation_id:
+            session_id = self._resume_conversation_id
+            self._resume_conversation_id = None
+            logger.info(f"Resuming conversation: {session_id}")
+            return session_id, True
+
+        return str(uuid.uuid4()), False
+
+    @staticmethod
+    def _validate_session_id(session_id: str) -> None:
+        """Validate that a session ID is a UUID string."""
+        try:
+            UUID(session_id)
+        except ValueError as exc:
+            raise RequestError.invalid_params(
+                {"reason": "Invalid session ID format", "sessionId": session_id}
+            ) from exc
+
+    @staticmethod
+    def _build_load_session_response(
+        conversation: BaseConversation,
+    ) -> LoadSessionResponse:
+        """Build a load-session response using the conversation's current mode."""
+        current_mode = get_confirmation_mode_from_conversation(conversation)
+        return LoadSessionResponse(modes=get_session_mode_state(current_mode))
+
+    @staticmethod
+    def _build_new_session_response(
+        session_id: str, conversation: BaseConversation
+    ) -> NewSessionResponse:
+        """Build a new-session response using the conversation's current mode."""
+        current_mode = get_confirmation_mode_from_conversation(conversation)
+        return NewSessionResponse(
+            session_id=session_id,
+            modes=get_session_mode_state(current_mode),
+        )
+
+    async def _replay_conversation_events(
+        self, session_id: str, events: list[Event], context: str
+    ) -> None:
+        """Replay stored conversation events to the connected ACP client."""
+        if not events:
+            return
+
+        logger.info(f"Replaying {len(events)} historic events {context}")
+        subscriber = EventSubscriber(session_id, self._conn)
+        for event in events:
+            await subscriber(event)
+
+    async def _send_agent_text_chunk(self, session_id: str, text: str) -> None:
+        """Send a text chunk update to the ACP client."""
+        await self._conn.session_update(
+            session_id=session_id,
+            update=AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=TextContentBlock(type="text", text=text),
+            ),
+        )
+
+    async def _get_slash_command_response(
+        self, session_id: str, command: str, argument: str
+    ) -> str:
+        """Execute a slash command and return its text response."""
+        if command == "help":
+            return create_help_text()
+        if command == "confirm":
+            return await self._cmd_confirm(session_id, argument)
+        return get_unknown_command_text(command)
+
+    async def _handle_slash_command(
+        self, session_id: str, command: str, argument: str
+    ) -> PromptResponse:
+        """Execute a slash command and send its response back to the client."""
+        response_text = await self._get_slash_command_response(
+            session_id=session_id,
+            command=command,
+            argument=argument,
+        )
+        await self._send_agent_text_chunk(session_id=session_id, text=response_text)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def _run_conversation_task(
+        self, session_id: str, conversation: BaseConversation
+    ) -> None:
+        """Run a conversation and track its task for cancellation support."""
+        run_task = asyncio.create_task(
+            run_conversation_with_confirmation(
+                conversation=conversation,
+                conn=self._conn,
+                session_id=session_id,
+            )
+        )
+
+        self._running_tasks[session_id] = run_task
+        try:
+            await run_task
+        finally:
+            self._running_tasks.pop(session_id, None)
 
     async def initialize(
         self,
@@ -449,14 +552,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         if mcp_servers:
             mcp_servers_dict = convert_acp_mcp_servers_to_agent_format(mcp_servers)
 
-        is_resuming = False
-        if self._resume_conversation_id:
-            session_id = self._resume_conversation_id
-            self._resume_conversation_id = None
-            is_resuming = True
-            logger.info(f"Resuming conversation: {session_id}")
-        else:
-            session_id = str(uuid.uuid4())
+        session_id, is_resuming = self._get_new_session_context()
 
         try:
             conversation = await self._get_or_create_conversation(
@@ -467,22 +563,14 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             )
 
             logger.info(f"Created new {self.agent_type} session {session_id}")
+            response = self._build_new_session_response(session_id, conversation)
 
-            current_mode = get_confirmation_mode_from_conversation(conversation)
-
-            response = NewSessionResponse(
-                session_id=session_id,
-                modes=get_session_mode_state(current_mode),
-            )
-
-            if is_resuming and conversation.state.events:
-                logger.info(
-                    f"Replaying {len(conversation.state.events)} historic events "
-                    f"for resumed session {session_id}"
+            if is_resuming:
+                await self._replay_conversation_events(
+                    session_id=session_id,
+                    events=conversation.state.events,
+                    context=f"for resumed session {session_id}",
                 )
-                subscriber = EventSubscriber(session_id, self._conn)
-                for event in conversation.state.events:
-                    await subscriber(event)
 
             # Schedule available commands notification to be sent after the response.
             # This ensures the client receives the NewSessionResponse (with sessionId)
@@ -541,44 +629,19 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             if slash_cmd:
                 command, argument = slash_cmd
                 logger.info(f"Executing slash command: /{command} {argument}")
-
-                # Execute the slash command
-                if command == "help":
-                    response_text = create_help_text()
-                elif command == "confirm":
-                    response_text = await self._cmd_confirm(session_id, argument)
-                else:
-                    response_text = get_unknown_command_text(command)
-
-                # Send response to client
-                await self._conn.session_update(
+                return await self._handle_slash_command(
                     session_id=session_id,
-                    update=AgentMessageChunk(
-                        session_update="agent_message_chunk",
-                        content=TextContentBlock(type="text", text=response_text),
-                    ),
+                    command=command,
+                    argument=argument,
                 )
-
-                return PromptResponse(stop_reason="end_turn")
 
             # Send the message with potentially multiple content types
             message = Message(role="user", content=message_content)
             conversation.send_message(message)
-
-            # Run the conversation with confirmation mode via runner function
-            run_task = asyncio.create_task(
-                run_conversation_with_confirmation(
-                    conversation=conversation,
-                    conn=self._conn,
-                    session_id=session_id,
-                )
+            await self._run_conversation_task(
+                session_id=session_id,
+                conversation=conversation,
             )
-
-            self._running_tasks[session_id] = run_task
-            try:
-                await run_task
-            finally:
-                self._running_tasks.pop(session_id, None)
 
             return PromptResponse(stop_reason="end_turn")
 
@@ -586,13 +649,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             raise
         except Exception as e:
             logger.error(f"Error processing prompt: {e}", exc_info=True)
-            await self._conn.session_update(
-                session_id=session_id,
-                update=AgentMessageChunk(
-                    session_update="agent_message_chunk",
-                    content=TextContentBlock(type="text", text=f"Error: {str(e)}"),
-                ),
-            )
+            await self._send_agent_text_chunk(session_id=session_id, text=f"Error: {e}")
             raise RequestError.internal_error(
                 {"reason": "Failed to process prompt", "details": str(e)}
             )
@@ -608,18 +665,10 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
 
         Default implementation for local agent. Cloud agent should override.
         """
-        from uuid import UUID
-
         logger.info(f"Loading session: {session_id}")
 
         try:
-            # Validate session ID format
-            try:
-                UUID(session_id)
-            except ValueError:
-                raise RequestError.invalid_params(
-                    {"reason": "Invalid session ID format", "sessionId": session_id}
-                )
+            self._validate_session_id(session_id)
 
             # Get or create conversation (loads from disk if not in cache)
             conversation = await self._get_or_create_conversation(session_id=session_id)
@@ -629,27 +678,20 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
                 logger.warning(
                     f"Session {session_id} has no history (new or empty session)"
                 )
-                current_mode = get_confirmation_mode_from_conversation(conversation)
-                return LoadSessionResponse(modes=get_session_mode_state(current_mode))
+                return self._build_load_session_response(conversation)
 
-            # Stream conversation history to client
-            logger.info(
-                f"Streaming {len(conversation.state.events)} events from "
-                f"conversation history"
+            await self._replay_conversation_events(
+                session_id=session_id,
+                events=conversation.state.events,
+                context="from conversation history",
             )
-            subscriber = EventSubscriber(session_id, self._conn)
-            for event in conversation.state.events:
-                await subscriber(event)
 
             logger.info(f"Successfully loaded session {session_id}")
 
             # Send available slash commands to client
             await self.send_available_commands(session_id)
 
-            # Get current confirmation mode for this session
-            current_mode = get_confirmation_mode_from_conversation(conversation)
-
-            return LoadSessionResponse(modes=get_session_mode_state(current_mode))
+            return self._build_load_session_response(conversation)
 
         except RequestError:
             raise

--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -243,25 +243,6 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
                 {"reason": "Invalid session ID format", "sessionId": session_id}
             ) from exc
 
-    @staticmethod
-    def _build_load_session_response(
-        conversation: BaseConversation,
-    ) -> LoadSessionResponse:
-        """Build a load-session response using the conversation's current mode."""
-        current_mode = get_confirmation_mode_from_conversation(conversation)
-        return LoadSessionResponse(modes=get_session_mode_state(current_mode))
-
-    @staticmethod
-    def _build_new_session_response(
-        session_id: str, conversation: BaseConversation
-    ) -> NewSessionResponse:
-        """Build a new-session response using the conversation's current mode."""
-        current_mode = get_confirmation_mode_from_conversation(conversation)
-        return NewSessionResponse(
-            session_id=session_id,
-            modes=get_session_mode_state(current_mode),
-        )
-
     async def _replay_conversation_events(
         self, session_id: str, events: Sequence[Event], context: str
     ) -> None:
@@ -284,25 +265,17 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             ),
         )
 
-    async def _get_slash_command_response(
-        self, session_id: str, command: str, argument: str
-    ) -> str:
-        """Execute a slash command and return its text response."""
-        if command == "help":
-            return create_help_text()
-        if command == "confirm":
-            return await self._cmd_confirm(session_id, argument)
-        return get_unknown_command_text(command)
-
     async def _handle_slash_command(
         self, session_id: str, command: str, argument: str
     ) -> PromptResponse:
         """Execute a slash command and send its response back to the client."""
-        response_text = await self._get_slash_command_response(
-            session_id=session_id,
-            command=command,
-            argument=argument,
-        )
+        if command == "help":
+            response_text = create_help_text()
+        elif command == "confirm":
+            response_text = await self._cmd_confirm(session_id, argument)
+        else:
+            response_text = get_unknown_command_text(command)
+
         await self._send_agent_text_chunk(session_id=session_id, text=response_text)
         return PromptResponse(stop_reason="end_turn")
 
@@ -563,7 +536,11 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             )
 
             logger.info(f"Created new {self.agent_type} session {session_id}")
-            response = self._build_new_session_response(session_id, conversation)
+            current_mode = get_confirmation_mode_from_conversation(conversation)
+            response = NewSessionResponse(
+                session_id=session_id,
+                modes=get_session_mode_state(current_mode),
+            )
 
             if is_resuming:
                 await self._replay_conversation_events(
@@ -674,11 +651,14 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             conversation = await self._get_or_create_conversation(session_id=session_id)
 
             # Check if there's actually any history to load
+            current_mode = get_confirmation_mode_from_conversation(conversation)
+            response = LoadSessionResponse(modes=get_session_mode_state(current_mode))
+
             if not conversation.state.events:
                 logger.warning(
                     f"Session {session_id} has no history (new or empty session)"
                 )
-                return self._build_load_session_response(conversation)
+                return response
 
             await self._replay_conversation_events(
                 session_id=session_id,
@@ -691,7 +671,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             # Send available slash commands to client
             await self.send_available_commands(session_id)
 
-            return self._build_load_session_response(conversation)
+            return response
 
         except RequestError:
             raise

--- a/tests/acp/test_base_agent.py
+++ b/tests/acp/test_base_agent.py
@@ -125,6 +125,86 @@ class TestAuthenticate:
         )
 
 
+class TestBaseAgentHelpers:
+    """Tests for the focused helper methods extracted from BaseOpenHandsACPAgent."""
+
+    @pytest.mark.asyncio
+    async def test_send_agent_text_chunk_sends_text_update(self, test_agent):
+        """_send_agent_text_chunk should wrap plain text in an ACP text update."""
+        session_id = str(uuid4())
+
+        await test_agent._send_agent_text_chunk(session_id, "Hello from helper")
+
+        test_agent._conn.session_update.assert_awaited_once()
+        call_kwargs = test_agent._conn.session_update.await_args.kwargs
+        assert call_kwargs["session_id"] == session_id
+        assert call_kwargs["update"].session_update == "agent_message_chunk"
+        assert call_kwargs["update"].content.text == "Hello from helper"
+
+    @pytest.mark.asyncio
+    async def test_handle_slash_command_help_sends_help_text(self, test_agent):
+        """_handle_slash_command should send a help response to the client."""
+        session_id = str(uuid4())
+
+        response = await test_agent._handle_slash_command(
+            session_id=session_id,
+            command="help",
+            argument="",
+        )
+
+        assert response.stop_reason == "end_turn"
+        call_kwargs = test_agent._conn.session_update.await_args.kwargs
+        assert call_kwargs["session_id"] == session_id
+        assert "Available slash commands" in call_kwargs["update"].content.text
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_task_tracks_and_cleans_up_task(self, test_agent):
+        """_run_conversation_task should register the task while it is running."""
+        session_id = str(uuid4())
+        mock_conversation = MagicMock()
+
+        async def fake_runner(*, conversation, conn, session_id: str):
+            assert conversation is mock_conversation
+            assert conn is test_agent._conn
+            assert session_id in test_agent._running_tasks
+
+        with patch(
+            "openhands_cli.acp_impl.agent.base_agent.run_conversation_with_confirmation",
+            side_effect=fake_runner,
+        ) as mock_runner:
+            await test_agent._run_conversation_task(session_id, mock_conversation)
+
+        mock_runner.assert_awaited_once_with(
+            conversation=mock_conversation,
+            conn=test_agent._conn,
+            session_id=session_id,
+        )
+        assert session_id not in test_agent._running_tasks
+
+    @pytest.mark.asyncio
+    async def test_replay_conversation_events_replays_each_event(
+        self, test_agent, mock_connection
+    ):
+        """_replay_conversation_events should forward each event via EventSubscriber."""
+        session_id = str(uuid4())
+        events = [MagicMock(), MagicMock()]
+
+        with patch(
+            "openhands_cli.acp_impl.agent.base_agent.EventSubscriber"
+        ) as mock_subscriber_class:
+            mock_subscriber = AsyncMock()
+            mock_subscriber_class.return_value = mock_subscriber
+
+            await test_agent._replay_conversation_events(
+                session_id=session_id,
+                events=events,
+                context="for testing",
+            )
+
+        mock_subscriber_class.assert_called_once_with(session_id, mock_connection)
+        assert mock_subscriber.await_count == len(events)
+
+
 class TestNewSession:
     """Tests for the new_session method."""
 

--- a/tests/acp/test_base_agent.py
+++ b/tests/acp/test_base_agent.py
@@ -158,21 +158,23 @@ class TestBaseAgentHelpers:
         assert "Available slash commands" in call_kwargs["update"].content.text
 
     @pytest.mark.asyncio
-    async def test_run_conversation_task_tracks_and_cleans_up_task(self, test_agent):
-        """_run_conversation_task should register the task while it is running."""
+    async def test_run_conversation_task_cleans_up_task_after_error(self, test_agent):
+        """_run_conversation_task should always clean up its tracking entry."""
         session_id = str(uuid4())
         mock_conversation = MagicMock()
 
-        async def fake_runner(*, conversation, conn, session_id: str):
+        async def failing_runner(*, conversation, conn, session_id: str):
             assert conversation is mock_conversation
             assert conn is test_agent._conn
             assert session_id in test_agent._running_tasks
+            raise RuntimeError("runner failed")
 
         with patch(
             "openhands_cli.acp_impl.agent.base_agent.run_conversation_with_confirmation",
-            side_effect=fake_runner,
+            side_effect=failing_runner,
         ) as mock_runner:
-            await test_agent._run_conversation_task(session_id, mock_conversation)
+            with pytest.raises(RuntimeError, match="runner failed"):
+                await test_agent._run_conversation_task(session_id, mock_conversation)
 
         mock_runner.assert_awaited_once_with(
             conversation=mock_conversation,
@@ -182,27 +184,44 @@ class TestBaseAgentHelpers:
         assert session_id not in test_agent._running_tasks
 
     @pytest.mark.asyncio
-    async def test_replay_conversation_events_replays_each_event(
-        self, test_agent, mock_connection
-    ):
-        """_replay_conversation_events should forward each event via EventSubscriber."""
+    async def test_replay_conversation_events_streams_real_events(self, test_agent):
+        """_replay_conversation_events should stream real agent messages."""
+        from openhands.sdk import Message, TextContent
+        from openhands.sdk.event.llm_convertible.message import MessageEvent
+
         session_id = str(uuid4())
-        events = [MagicMock(), MagicMock()]
+        events = [
+            MessageEvent(
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text="First reply")],
+                ),
+            ),
+            MessageEvent(
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text="Second reply")],
+                ),
+            ),
+        ]
 
-        with patch(
-            "openhands_cli.acp_impl.agent.base_agent.EventSubscriber"
-        ) as mock_subscriber_class:
-            mock_subscriber = AsyncMock()
-            mock_subscriber_class.return_value = mock_subscriber
+        await test_agent._replay_conversation_events(
+            session_id=session_id,
+            events=events,
+            context="for testing",
+        )
 
-            await test_agent._replay_conversation_events(
-                session_id=session_id,
-                events=events,
-                context="for testing",
-            )
-
-        mock_subscriber_class.assert_called_once_with(session_id, mock_connection)
-        assert mock_subscriber.await_count == len(events)
+        assert test_agent._conn.session_update.await_count == len(events)
+        updates = [
+            call.kwargs["update"]
+            for call in test_agent._conn.session_update.await_args_list
+        ]
+        assert [update.content.text for update in updates] == [
+            "First reply",
+            "Second reply",
+        ]
 
 
 class TestNewSession:

--- a/tests/acp/test_base_agent.py
+++ b/tests/acp/test_base_agent.py
@@ -2,15 +2,17 @@
 
 import asyncio
 from collections.abc import Mapping
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from acp import RequestError
-from acp.schema import Implementation
+from acp.schema import Implementation, TextContentBlock
 
 from openhands.sdk import BaseConversation
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm
 from openhands_cli.acp_impl.agent.base_agent import BaseOpenHandsACPAgent
 from openhands_cli.acp_impl.agent.util import AgentType
 from openhands_cli.acp_impl.confirmation import ConfirmationMode
@@ -66,6 +68,38 @@ def mock_connection():
 def test_agent(mock_connection):
     """Create a ConcreteTestAgent instance."""
     return ConcreteTestAgent(mock_connection)
+
+
+class RecordingConnection:
+    """Minimal ACP connection that records session updates for assertions."""
+
+    def __init__(self) -> None:
+        self.session_updates: list[dict[str, Any]] = []
+
+    async def session_update(self, **kwargs: Any) -> None:
+        self.session_updates.append(kwargs)
+
+
+@pytest.fixture
+def recording_connection() -> RecordingConnection:
+    """Create a connection that records updates instead of mocking them."""
+    return RecordingConnection()
+
+
+@pytest.fixture
+def recording_agent(recording_connection: RecordingConnection):
+    """Create a ConcreteTestAgent backed by a recording connection."""
+    return ConcreteTestAgent(recording_connection)
+
+
+def make_test_conversation(*events: Any) -> MagicMock:
+    """Create a conversation double with realistic state for base-agent tests."""
+    conversation = MagicMock()
+    conversation.state = SimpleNamespace(
+        events=list(events),
+        confirmation_policy=AlwaysConfirm(),
+    )
+    return conversation
 
 
 class TestInitialize:
@@ -125,72 +159,74 @@ class TestAuthenticate:
         )
 
 
-class TestBaseAgentHelpers:
-    """Tests for the focused helper methods extracted from BaseOpenHandsACPAgent."""
+class TestPrompt:
+    """Tests for prompt handling behavior."""
 
     @pytest.mark.asyncio
-    async def test_send_agent_text_chunk_sends_text_update(self, test_agent):
-        """_send_agent_text_chunk should wrap plain text in an ACP text update."""
+    async def test_prompt_help_command_streams_help_text(self, recording_agent):
+        """Prompting /help should send the rendered help text to the client."""
         session_id = str(uuid4())
+        recording_agent._mock_conversation = make_test_conversation()
 
-        await test_agent._send_agent_text_chunk(session_id, "Hello from helper")
-
-        test_agent._conn.session_update.assert_awaited_once()
-        call_kwargs = test_agent._conn.session_update.await_args.kwargs
-        assert call_kwargs["session_id"] == session_id
-        assert call_kwargs["update"].session_update == "agent_message_chunk"
-        assert call_kwargs["update"].content.text == "Hello from helper"
-
-    @pytest.mark.asyncio
-    async def test_handle_slash_command_help_sends_help_text(self, test_agent):
-        """_handle_slash_command should send a help response to the client."""
-        session_id = str(uuid4())
-
-        response = await test_agent._handle_slash_command(
+        response = await recording_agent.prompt(
             session_id=session_id,
-            command="help",
-            argument="",
+            prompt=[TextContentBlock(type="text", text="/help")],
         )
 
         assert response.stop_reason == "end_turn"
-        call_kwargs = test_agent._conn.session_update.await_args.kwargs
-        assert call_kwargs["session_id"] == session_id
-        assert "Available slash commands" in call_kwargs["update"].content.text
+        assert len(recording_agent._conn.session_updates) == 1
+        update_call = recording_agent._conn.session_updates[0]
+        assert update_call["session_id"] == session_id
+        assert update_call["update"].session_update == "agent_message_chunk"
+        assert "Available slash commands" in update_call["update"].content.text
 
     @pytest.mark.asyncio
-    async def test_run_conversation_task_cleans_up_task_after_error(self, test_agent):
-        """_run_conversation_task should always clean up its tracking entry."""
+    async def test_prompt_runner_failure_cleans_up_task_and_streams_error(
+        self, recording_agent
+    ):
+        """Prompt should clear running-task tracking and stream the failure text."""
         session_id = str(uuid4())
-        mock_conversation = MagicMock()
+        mock_conversation = make_test_conversation()
+        recording_agent._mock_conversation = mock_conversation
 
         async def failing_runner(*, conversation, conn, session_id: str):
             assert conversation is mock_conversation
-            assert conn is test_agent._conn
-            assert session_id in test_agent._running_tasks
+            assert conn is recording_agent._conn
+            assert session_id in recording_agent._running_tasks
             raise RuntimeError("runner failed")
 
         with patch(
             "openhands_cli.acp_impl.agent.base_agent.run_conversation_with_confirmation",
             side_effect=failing_runner,
-        ) as mock_runner:
-            with pytest.raises(RuntimeError, match="runner failed"):
-                await test_agent._run_conversation_task(session_id, mock_conversation)
+        ):
+            with pytest.raises(RequestError) as exc_info:
+                await recording_agent.prompt(
+                    session_id=session_id,
+                    prompt=[TextContentBlock(type="text", text="Hello")],
+                )
 
-        mock_runner.assert_awaited_once_with(
-            conversation=mock_conversation,
-            conn=test_agent._conn,
-            session_id=session_id,
-        )
-        assert session_id not in test_agent._running_tasks
+        assert exc_info.value.data is not None
+        assert exc_info.value.data["reason"] == "Failed to process prompt"
+        assert exc_info.value.data["details"] == "runner failed"
+        assert session_id not in recording_agent._running_tasks
+        assert [
+            update["update"].content.text
+            for update in recording_agent._conn.session_updates
+            if update["update"].session_update == "agent_message_chunk"
+        ] == ["Error: runner failed"]
+
+
+class TestLoadSession:
+    """Tests for the load_session method."""
 
     @pytest.mark.asyncio
-    async def test_replay_conversation_events_streams_real_events(self, test_agent):
-        """_replay_conversation_events should stream real agent messages."""
+    async def test_load_session_streams_real_message_events(self, recording_agent):
+        """load_session should replay real message events through EventSubscriber."""
         from openhands.sdk import Message, TextContent
         from openhands.sdk.event.llm_convertible.message import MessageEvent
 
         session_id = str(uuid4())
-        events = [
+        recording_agent._mock_conversation = make_test_conversation(
             MessageEvent(
                 source="agent",
                 llm_message=Message(
@@ -205,23 +241,21 @@ class TestBaseAgentHelpers:
                     content=[TextContent(text="Second reply")],
                 ),
             ),
-        ]
-
-        await test_agent._replay_conversation_events(
-            session_id=session_id,
-            events=events,
-            context="for testing",
         )
 
-        assert test_agent._conn.session_update.await_count == len(events)
-        updates = [
-            call.kwargs["update"]
-            for call in test_agent._conn.session_update.await_args_list
-        ]
-        assert [update.content.text for update in updates] == [
-            "First reply",
-            "Second reply",
-        ]
+        response = await recording_agent.load_session(
+            cwd="/tmp",
+            mcp_servers=[],
+            session_id=session_id,
+        )
+
+        assert response is not None
+        assert response.modes is not None
+        assert [
+            update["update"].content.text
+            for update in recording_agent._conn.session_updates
+            if update["update"].session_update == "agent_message_chunk"
+        ] == ["First reply", "Second reply"]
 
 
 class TestNewSession:
@@ -272,28 +306,41 @@ class TestNewSession:
         assert len(response.modes.available_modes) == 3
 
     @pytest.mark.asyncio
-    async def test_new_session_replays_events_on_resume(self, mock_connection):
+    async def test_new_session_replays_events_on_resume(self, recording_connection):
         """Test new_session replays historic events when resuming."""
+        from openhands.sdk import Message, TextContent
+        from openhands.sdk.event.llm_convertible.message import MessageEvent
+
         resume_id = str(uuid4())
-        agent = ConcreteTestAgent(mock_connection, resume_conversation_id=resume_id)
+        agent = ConcreteTestAgent(
+            recording_connection,
+            resume_conversation_id=resume_id,
+        )
+        agent._mock_conversation = make_test_conversation(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text="First reply")],
+                ),
+            ),
+            MessageEvent(
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text="Second reply")],
+                ),
+            ),
+        )
 
-        # Create mock events
-        mock_event1 = MagicMock()
-        mock_event2 = MagicMock()
-        mock_conversation = MagicMock()
-        mock_conversation.state.events = [mock_event1, mock_event2]
-        agent._mock_conversation = mock_conversation
+        response = await agent.new_session(cwd="/tmp", mcp_servers=[])
 
-        with patch(
-            "openhands_cli.acp_impl.agent.base_agent.EventSubscriber"
-        ) as mock_subscriber_class:
-            mock_subscriber = AsyncMock()
-            mock_subscriber_class.return_value = mock_subscriber
-
-            await agent.new_session(cwd="/tmp", mcp_servers=[])
-
-            # Verify events were replayed
-            assert mock_subscriber.call_count == 2
+        assert response.session_id == resume_id
+        assert [
+            update["update"].content.text
+            for update in recording_connection.session_updates
+            if update["update"].session_update == "agent_message_chunk"
+        ] == ["First reply", "Second reply"]
 
     @pytest.mark.asyncio
     async def test_new_session_handles_missing_agent_spec(self, mock_connection):


### PR DESCRIPTION
## Summary
- extract focused helper methods from `BaseOpenHandsACPAgent` for session context, slash-command replies, event replay, and conversation task execution
- simplify `new_session`, `prompt`, and `load_session` so the file is easier to maintain without changing ACP behavior
- add targeted ACP coverage in `tests/acp/test_base_agent.py`, favoring public-method paths and real event replay, and record the recommended ACP regression tests in `AGENTS.md`

Closes #618.

## Why
The code quality report called out `openhands_cli/acp_impl/agent/base_agent.py` as a large file with mixed responsibilities. This PR follows the same approach we took for `richlog_visualizer`: make a small, behavior-preserving refactor instead of attempting a large split.

## Testing
- `make lint`
- `make test`
- `make test-binary`
- `uv run pytest tests/acp/test_base_agent.py -q`
- `uv run pytest tests/acp/test_agent_common.py tests/acp/test_agent.py -q`
- `uv run ruff check tests/acp/test_base_agent.py openhands_cli/acp_impl/agent/base_agent.py`

## PR checklist
- [x] Scope is minimal and focused on one change
- [x] Tests added/updated for behavior changes
- [x] `make lint`
- [x] `make test`
- [x] `make test-binary`
- [ ] `make test-snapshots` (not applicable; no TUI changes)
- [x] PR description includes what changed, why, and commands run

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/refactor-base-agent-helpers
```
