### PR TITLE
feat: add live LLM integration tests (label-triggered CI)

### DIFF
--- a/.github/workflows/live-llm-tests.yml
+++ b/.github/workflows/live-llm-tests.yml
@@ -1,0 +1,148 @@
+---
+# Live LLM integration tests — runs the real CLI against a real LLM.
+# Trigger: PR label "run-live-llm", manual dispatch, or nightly schedule.
+name: Live LLM Integration Tests
+
+on:
+    pull_request:
+        types: [labeled]
+    workflow_dispatch:
+        inputs:
+            reason:
+                description: Reason for manual trigger
+                required: false
+                default: ''
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+concurrency:
+    group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    live-llm-tests:
+        if: >-
+            github.event.label.name == 'run-live-llm'
+            || github.event_name == 'workflow_dispatch'
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 30
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.12'
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v3
+              with:
+                  version: latest
+
+            - name: Install dependencies
+              run: uv sync --group dev
+
+            - name: Run live LLM integration tests
+              env:
+                  LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                  LLM_MODEL: ${{ vars.LIVE_LLM_MODEL || 'openhands/claude-haiku-4-5-20251001' }}
+                  LLM_BASE_URL: ${{ vars.LIVE_LLM_BASE_URL || 'https://llm-proxy.app.all-hands.dev' }}
+                  LIVE_LLM_TIMEOUT: '300'
+              run: |
+                  RESULTS_DIR=".live-llm-results"
+                  rm -rf "$RESULTS_DIR"
+                  mkdir -p "$RESULTS_DIR"
+
+                  EXIT_CODE=0
+                  uv run pytest tests/live_llm/ \
+                      --run-live-llm \
+                      --live-llm-results-dir "$RESULTS_DIR" \
+                      -v --tb=long \
+                      2>&1 | tee live-llm-output.log || EXIT_CODE=$?
+
+                  echo "EXIT_CODE=$EXIT_CODE" >> "$GITHUB_ENV"
+                  exit 0  # Don't fail yet — comment first
+
+            - name: Build PR comment
+              if: github.event_name == 'pull_request'
+              id: build_comment
+              run: |
+                  RESULTS_DIR=".live-llm-results"
+                  MODEL="${LLM_MODEL:-unknown}"
+                  WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+                  {
+                    echo "## 🧪 Live LLM Integration Tests"
+                    echo ""
+                    echo "**Model:** \`${MODEL}\`"
+                    echo "**Workflow:** [View run](${WORKFLOW_URL})"
+                    echo ""
+
+                    # Parse JSON results
+                    TOTAL=0
+                    PASSED=0
+                    FAILED=0
+                    DETAILS=""
+
+                    for f in "$RESULTS_DIR"/*.json; do
+                      [ -f "$f" ] || continue
+                      TOTAL=$((TOTAL + 1))
+                      STATUS=$(jq -r '.status' "$f")
+                      TEST=$(jq -r '.test' "$f")
+                      DURATION=$(jq -r '.duration_seconds' "$f")
+                      DURATION_FMT=$(printf "%.1f" "$DURATION")
+
+                      if [ "$STATUS" = "passed" ]; then
+                        PASSED=$((PASSED + 1))
+                        DETAILS="${DETAILS}| ✅ | \`${TEST}\` | ${DURATION_FMT}s |\n"
+                      else
+                        FAILED=$((FAILED + 1))
+                        TIMED_OUT=$(jq -r '.timed_out' "$f")
+                        REASON="exit code $(jq -r '.returncode' "$f")"
+                        [ "$TIMED_OUT" = "true" ] && REASON="timed out"
+                        DETAILS="${DETAILS}| ❌ | \`${TEST}\` | ${DURATION_FMT}s (${REASON}) |\n"
+                      fi
+                    done
+
+                    if [ "$TOTAL" -eq 0 ]; then
+                      echo "⚠️ No test results found."
+                    else
+                      echo "**Results:** ${PASSED}/${TOTAL} passed"
+                      echo ""
+                      echo "| Status | Test | Duration |"
+                      echo "|--------|------|----------|"
+                      echo -e "$DETAILS"
+                    fi
+
+                    echo ""
+                    echo "<details><summary>Full log (last 100 lines)</summary>"
+                    echo ""
+                    echo '```'
+                    tail -100 live-llm-output.log
+                    echo '```'
+                    echo "</details>"
+                  } > comment_body.md
+
+                  # Store for the next step
+                  echo "comment_path=comment_body.md" >> "$GITHUB_OUTPUT"
+              env:
+                  LLM_MODEL: ${{ vars.LIVE_LLM_MODEL || 'openhands/claude-haiku-4-5-20251001' }}
+
+            - name: Post/update PR comment
+              if: github.event_name == 'pull_request'
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: live-llm-tests
+                  path: comment_body.md
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Fail if tests failed
+              if: env.EXIT_CODE != '0'
+              run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ $RECYCLE.BIN/
 .pytest_cache/
 software-agent-sdk/
 snapshot_report.html
+.live-llm-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ This repository uses **uv** for dependency management and running tooling (such 
 - run snapshot tests (Textual UI): `make test-snapshots` (or `uv run pytest tests/snapshots -v`; use `--snapshot-update` when updating snapshots)
 - run binary tests: `make test-binary` (or `uv run pytest tui_e2e`)
 - run unit/integration + snapshot tests together: `make test-all`
+- run live LLM integration tests: `make test-live-llm` (requires `LLM_API_KEY` and `LLM_MODEL` env vars; see `tests/live_llm/README.md`)
 - build PyInstaller binaries: `./build.sh --install-pyinstaller`
 
 ## Development Guidelines
@@ -70,9 +71,10 @@ Prefer modern typing syntax (`X | None` over `Optional[X]`) in new code.
 - Type checking via `pyright` (`uv run pyright`); prefer type hints on new functions and public interfaces.
 
 ## Testing Guidelines
-- Unit/integration tests live under `tests/` (excluding `tests/snapshots`) and run via `make test`.
+- Unit/integration tests live under `tests/` (excluding `tests/snapshots` and `tests/live_llm`) and run via `make test`.
 - Snapshot tests live under `tests/snapshots/` and run via `make test-snapshots`.
 - Binary tests live under `tui_e2e/` and run via `make test-binary`.
+- Live LLM tests live under `tests/live_llm/` and run via `make test-live-llm` (opt-in, requires `--run-live-llm` flag + `LLM_API_KEY`/`LLM_MODEL` env vars). In CI, triggered by the `run-live-llm` PR label.
 - Pytest discovery: files `test_*.py`, classes `Test*`, functions `test_*`. Use `@pytest.mark.integration` for costly flows.
 - Match test locations to implementation (`tests/` mirrors `openhands_cli/`); add fixtures in `tests/conftest.py` when shared.
 - Run `make test` before PRs; run snapshot/binary tests when relevant to the change.

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ help:
 	@$(ECHO) "  $(CYAN)test$(RESET)              Run tests"
 	@$(ECHO) "  $(CYAN)test-snapshots$(RESET)    Run tests snapshots"
 	@$(ECHO) "  $(CYAN)test-binary$(RESET)       Run end-to-end tests"
+	@$(ECHO) "  $(CYAN)test-live-llm$(RESET)    Run live LLM integration tests (requires LLM_API_KEY, LLM_MODEL)"
 	@$(ECHO) "  $(CYAN)test-all$(RESET)          Run tests and tests-snapshots"
 	@$(ECHO) "  $(CYAN)lint$(RESET)              Lint code with Ruff"
 	@$(ECHO) "  $(CYAN)format$(RESET)            Format code with Ruff"
@@ -76,6 +77,11 @@ test-binary:
 	@$(ECHO) "$(YELLOW)Run end-to-end tests...$(RESET)"
 	uv run pytest tui_e2e
 	@$(ECHO) "$(GREEN)End-to-end tests completed.$(RESET)"
+
+test-live-llm:
+	@$(ECHO) "$(YELLOW)Run live LLM integration tests...$(RESET)"
+	uv run pytest tests/live_llm/ --run-live-llm -v
+	@$(ECHO) "$(GREEN)Live LLM tests completed.$(RESET)"
 
 test-all: test test-snapshots
 

--- a/tests/live_llm/README.md
+++ b/tests/live_llm/README.md
@@ -1,0 +1,62 @@
+# Live LLM Integration Tests
+
+End-to-end tests that run the **real CLI** against a **real LLM provider** in
+`--headless` mode.  They are intentionally expensive and opt-in.
+
+## Quick start
+
+```bash
+# Run locally (needs LLM credentials)
+LLM_API_KEY="sk-..." \
+LLM_MODEL="anthropic/claude-sonnet-4-5-20250929" \
+  uv run pytest tests/live_llm/ --run-live-llm -v
+
+# With a LiteLLM proxy
+LLM_API_KEY="..." \
+LLM_MODEL="openhands/claude-haiku-4-5-20251001" \
+LLM_BASE_URL="https://llm-proxy.app.all-hands.dev" \
+  uv run pytest tests/live_llm/ --run-live-llm -v
+```
+
+## How it works
+
+Each test:
+
+1. Calls the CLI via `python -m openhands_cli.entrypoint --headless --task "..." --override-with-envs --always-approve`
+2. Captures `stdout` / `stderr`
+3. Asserts **relaxed behavioural keywords** (not exact output)
+
+Tests are skipped automatically when `--run-live-llm` is not passed, so
+`make test` is unaffected.
+
+## CI trigger
+
+In CI, these tests are triggered by adding the **`run-live-llm`** label to a
+pull request (see `.github/workflows/live-llm-tests.yml`).  Results are
+posted as a PR comment.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `LLM_API_KEY` | ✅ | API key for the LLM provider |
+| `LLM_MODEL` | ✅ | Model identifier (e.g. `anthropic/claude-sonnet-4-5-20250929`) |
+| `LLM_BASE_URL` | ❌ | Custom base URL (e.g. a LiteLLM proxy) |
+| `LIVE_LLM_TIMEOUT` | ❌ | Per-test timeout in seconds (default: `300`) |
+
+## Test design
+
+The three tests are chosen to maximise component coverage with minimal LLM calls:
+
+| Test | What it validates |
+|---|---|
+| `test_echo_command` | LLM connectivity → tool-call → terminal execution → observation → summary |
+| `test_file_create_and_read` | Multi-step planning, file I/O, observation correctness |
+| `test_python_code_gen_and_run` | Code generation, file creation, Python execution, numeric output |
+
+## Adding new tests
+
+1. Add a new test method/class in `test_live_llm.py`
+2. Use the `run_cli` fixture: `result = run_cli("your prompt")`
+3. Assert on `result.output` with relaxed keyword checks
+4. Keep prompts short and deterministic in expected behaviour

--- a/tests/live_llm/__init__.py
+++ b/tests/live_llm/__init__.py
@@ -1,0 +1,10 @@
+"""Live LLM integration tests.
+
+These tests run the real CLI with a real LLM provider to validate
+end-to-end behavior. They are disabled by default and require:
+
+1. ``--run-live-llm`` pytest flag to enable
+2. ``LLM_API_KEY`` and ``LLM_MODEL`` environment variables set
+
+See tests/live_llm/README.md for details.
+"""

--- a/tests/live_llm/conftest.py
+++ b/tests/live_llm/conftest.py
@@ -1,0 +1,236 @@
+"""Fixtures and configuration for live LLM integration tests.
+
+These tests execute the real CLI binary (via ``uv run openhands``) against a
+real LLM provider in ``--headless`` mode.  They are **opt-in**: pass
+``--run-live-llm`` to ``pytest`` to enable them.
+
+Required environment variables (when enabled):
+    LLM_API_KEY   – API key for the LLM provider
+    LLM_MODEL     – Model identifier (e.g. ``anthropic/claude-sonnet-4-5-20250929``)
+
+Optional:
+    LLM_BASE_URL  – Custom base URL (e.g. a LiteLLM proxy)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Pytest option
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("live_llm", "Live LLM integration tests")
+    group.addoption(
+        "--run-live-llm",
+        action="store_true",
+        default=False,
+        help="Execute live LLM integration tests (requires LLM_API_KEY and LLM_MODEL).",
+    )
+    group.addoption(
+        "--live-llm-results-dir",
+        action="store",
+        default=None,
+        help=(
+            "Directory to store per-test JSON result files "
+            "(default: .live-llm-results)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def live_llm_enabled(pytestconfig: pytest.Config) -> bool:
+    return bool(pytestconfig.getoption("--run-live-llm"))
+
+
+@pytest.fixture(scope="session")
+def live_llm_results_dir(pytestconfig: pytest.Config) -> Path:
+    configured = pytestconfig.getoption("--live-llm-results-dir")
+    result_dir = Path(configured) if configured else REPO_ROOT / ".live-llm-results"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    # Clean previous results on the controller (not on xdist workers)
+    if not hasattr(pytestconfig, "workerinput"):
+        for existing in result_dir.glob("*.json"):
+            existing.unlink()
+    return result_dir
+
+
+@pytest.fixture(scope="session")
+def llm_env() -> dict[str, str]:
+    """Return validated LLM environment variables."""
+    api_key = os.environ.get("LLM_API_KEY", "")
+    model = os.environ.get("LLM_MODEL", "")
+    base_url = os.environ.get("LLM_BASE_URL", "")
+    return {
+        "LLM_API_KEY": api_key,
+        "LLM_MODEL": model,
+        "LLM_BASE_URL": base_url,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-test fixture: runs the CLI headless
+# ---------------------------------------------------------------------------
+
+# Maximum wall-clock time for a single CLI invocation
+CLI_TIMEOUT_SECONDS = int(os.environ.get("LIVE_LLM_TIMEOUT", "300"))  # 5 min
+
+
+@dataclass
+class CLIResult:
+    """Result of running the CLI in headless mode."""
+
+    task: str
+    stdout: str
+    stderr: str
+    returncode: int
+    duration_seconds: float
+    timed_out: bool = False
+    work_dir: str = ""
+    env_snapshot: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def output(self) -> str:
+        """Combined stdout + stderr for assertion convenience."""
+        return self.stdout + "\n" + self.stderr
+
+
+def _run_cli_headless(
+    task: str,
+    *,
+    llm_env: dict[str, str],
+    work_dir: Path,
+    timeout: int = CLI_TIMEOUT_SECONDS,
+) -> CLIResult:
+    """Run ``uv run openhands --headless --task '...' --override-with-envs``."""
+    env = os.environ.copy()
+    env.update({k: v for k, v in llm_env.items() if v})
+    # Force the working directory so tools operate in a scratch space
+    env["OPENHANDS_WORK_DIR"] = str(work_dir)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "openhands_cli.entrypoint",
+        "--headless",
+        "--always-approve",
+        "--override-with-envs",
+        "--task",
+        task,
+    ]
+
+    start = time.perf_counter()
+    timed_out = False
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(REPO_ROOT),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+        stdout, stderr, returncode = proc.stdout, proc.stderr, proc.returncode
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        raw_out = exc.stdout
+        raw_err = exc.stderr
+        stdout = raw_out.decode() if isinstance(raw_out, bytes) else (raw_out or "")
+        stderr = raw_err.decode() if isinstance(raw_err, bytes) else (raw_err or "")
+        returncode = -1
+
+    duration = time.perf_counter() - start
+
+    return CLIResult(
+        task=task,
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode,
+        duration_seconds=duration,
+        timed_out=timed_out,
+        work_dir=str(work_dir),
+        env_snapshot={k: ("***" if "KEY" in k else v) for k, v in llm_env.items()},
+    )
+
+
+@pytest.fixture
+def run_cli(
+    live_llm_enabled: bool,
+    llm_env: dict[str, str],
+    live_llm_results_dir: Path,
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+):
+    """Fixture that provides a callable to run the CLI with a given task.
+
+    Usage::
+
+        def test_something(run_cli):
+            result = run_cli("echo hello")
+            assert "hello" in result.output
+    """
+    if not live_llm_enabled:
+        pytest.skip("Use --run-live-llm to execute live LLM integration tests.")
+
+    api_key = llm_env.get("LLM_API_KEY", "")
+    model = llm_env.get("LLM_MODEL", "")
+    if not api_key or not model:
+        pytest.skip(
+            "LLM_API_KEY and LLM_MODEL environment variables are required "
+            "for live LLM tests."
+        )
+
+    # Each test gets its own scratch workspace
+    work_dir = tmp_path / "workspace"
+    work_dir.mkdir()
+
+    results: list[CLIResult] = []
+
+    def _invoke(task: str, *, timeout: int = CLI_TIMEOUT_SECONDS) -> CLIResult:
+        result = _run_cli_headless(
+            task, llm_env=llm_env, work_dir=work_dir, timeout=timeout
+        )
+        results.append(result)
+        return result
+
+    yield _invoke
+
+    # Write JSON result file for CI reporting
+    for i, result in enumerate(results):
+        test_id = request.node.nodeid.replace("/", "__").replace("::", "__")
+        suffix = f"__{i}" if len(results) > 1 else ""
+        result_file = live_llm_results_dir / f"{test_id}{suffix}.json"
+        payload = {
+            "test": request.node.nodeid,
+            "task": result.task,
+            "status": (
+                "passed"
+                if result.returncode == 0 and not result.timed_out
+                else "failed"
+            ),
+            "duration_seconds": result.duration_seconds,
+            "returncode": result.returncode,
+            "timed_out": result.timed_out,
+            "stdout_tail": result.stdout[-2000:] if result.stdout else "",
+            "stderr_tail": result.stderr[-2000:] if result.stderr else "",
+        }
+        result_file.write_text(json.dumps(payload, indent=2))

--- a/tests/live_llm/test_live_llm.py
+++ b/tests/live_llm/test_live_llm.py
@@ -1,0 +1,139 @@
+"""Live LLM integration tests.
+
+Each test sends a prompt to the real CLI in ``--headless`` mode with a live
+LLM provider.  Assertions are intentionally **relaxed** — we check for
+behavioral keywords rather than exact output, because LLM responses are
+non-deterministic.
+
+Enable with ``--run-live-llm`` and set ``LLM_API_KEY`` / ``LLM_MODEL``.
+
+Test design rationale
+---------------------
+The three tests below are chosen to maximise component coverage with
+minimal LLM calls:
+
+1. **test_echo_command** — smoke test for the entire pipeline:
+   LLM connectivity → tool-call generation → terminal execution →
+   observation capture → agent summary.
+
+2. **test_file_create_and_read** — validates multi-step tool chaining:
+   the agent must plan two sequential operations (write then read) and
+   return the file contents.
+
+3. **test_python_code_generation_and_execution** — exercises code
+   generation, file creation (via either terminal or file_editor tool),
+   and Python execution in a single turn.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from tests.live_llm.conftest import CLIResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_cli_success(result: CLIResult) -> None:
+    """Common assertions: no timeout, process exited cleanly."""
+    assert not result.timed_out, (
+        f"CLI timed out after {result.duration_seconds:.0f}s.\n"
+        f"stdout tail: {result.stdout[-500:]}\n"
+        f"stderr tail: {result.stderr[-500:]}"
+    )
+    assert result.returncode == 0, (
+        f"CLI exited with code {result.returncode}.\n"
+        f"stdout tail: {result.stdout[-1000:]}\n"
+        f"stderr tail: {result.stderr[-1000:]}"
+    )
+
+
+def _output_contains_any(output: str, keywords: list[str]) -> bool:
+    """Check whether *output* contains at least one of *keywords* (case-insensitive)."""
+    lower = output.lower()
+    return any(kw.lower() in lower for kw in keywords)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — basic terminal command (smoke test)
+# ---------------------------------------------------------------------------
+# Components exercised:
+#   LLM connectivity, tool-call parsing, TerminalTool, observation routing,
+#   agent response generation, headless summary output, --override-with-envs.
+
+
+class TestEchoCommand:
+    """Verify the agent can execute a trivial terminal command."""
+
+    def test_echo_command(self, run_cli):
+        result: CLIResult = run_cli(
+            "Run this exact terminal command and show me the output: "
+            "echo 'hello from openhands'"
+        )
+        _assert_cli_success(result)
+
+        # The agent must have executed `echo` — the literal string should
+        # appear somewhere in the captured output (terminal observation or
+        # agent summary).
+        assert _output_contains_any(result.output, ["hello from openhands"]), (
+            "Expected 'hello from openhands' in CLI output.\n"
+            f"stdout tail:\n{result.stdout[-1000:]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — multi-step file create + read
+# ---------------------------------------------------------------------------
+# Components exercised:
+#   Multi-turn tool chain (write → read), file system operations via
+#   TerminalTool or FileEditorTool, observation correctness across turns,
+#   agent planning / sequencing.
+
+
+class TestFileCreateAndRead:
+    """Verify the agent can create a file and read it back."""
+
+    SENTINEL = "live-llm-integration-test-ok"
+
+    def test_file_create_and_read(self, run_cli):
+        result: CLIResult = run_cli(
+            f"Create a file called 'check.txt' containing exactly the text "
+            f"'{self.SENTINEL}', then read it back with cat and show me the output."
+        )
+        _assert_cli_success(result)
+
+        assert _output_contains_any(result.output, [self.SENTINEL]), (
+            f"Expected '{self.SENTINEL}' in CLI output.\n"
+            f"stdout tail:\n{result.stdout[-1000:]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — code generation + execution
+# ---------------------------------------------------------------------------
+# Components exercised:
+#   Code generation quality, file creation (file_editor or terminal),
+#   Python subprocess execution via TerminalTool, numeric output parsing,
+#   end-to-end multi-step flow.
+
+
+class TestCodeGenAndExecution:
+    """Verify the agent can write and run a Python script."""
+
+    def test_python_code_gen_and_run(self, run_cli):
+        result: CLIResult = run_cli(
+            "Write a Python script called calc.py that prints the result of 2**10, "
+            "then run it with python3 and show me the output."
+        )
+        _assert_cli_success(result)
+
+        # 2**10 == 1024 — should appear in agent output or terminal observation
+        assert _output_contains_any(result.output, ["1024"]), (
+            "Expected '1024' (2**10) in CLI output.\n"
+            f"stdout tail:\n{result.stdout[-1000:]}"
+        )


### PR DESCRIPTION
## What changed

Add a new test suite that runs the real CLI against a real LLM provider in `--headless` mode, validating the full end-to-end pipeline. Tests are opt-in and triggered by the `run-live-llm` PR label.

## Why

All existing "conversation tests" use mock LLM servers with trajectory replay. This new layer validates that the CLI actually works end-to-end with a real LLM — covering LLM connectivity, tool-call parsing, terminal execution, observation routing, multi-step planning, code generation, and headless output.

## New files

| File | Purpose |
|------|---------|
| `tests/live_llm/conftest.py` | `--run-live-llm` pytest option, `run_cli` fixture (headless subprocess wrapper), JSON result reporting |
| `tests/live_llm/test_live_llm.py` | 3 test cases (see below) |
| `tests/live_llm/README.md` | Usage docs |
| `.github/workflows/live-llm-tests.yml` | CI workflow: `run-live-llm` label trigger, PR comment with results |

## Test cases

3 prompts chosen to maximize component coverage with minimal LLM calls:

| Test | Prompt | Components covered |
|------|--------|--------------------|
| `test_echo_command` | `echo 'hello from openhands'` | LLM connectivity → tool-call parsing → TerminalTool → observation → agent summary → `--override-with-envs` |
| `test_file_create_and_read` | Create check.txt + cat it back | Multi-step planning, file I/O (write → read), cross-turn observation correctness |
| `test_python_code_gen_and_run` | Write calc.py (2\*\*10) + run it | Code generation, file creation, Python execution, numeric output |

## Verified

All 3 tests pass with `anthropic/claude-haiku-4-5-20251001` via LiteLLM proxy:
```
tests/live_llm/test_live_llm.py::TestEchoCommand::test_echo_command PASSED
tests/live_llm/test_live_llm.py::TestFileCreateAndRead::test_file_create_and_read PASSED
tests/live_llm/test_live_llm.py::TestCodeGenAndExecution::test_python_code_gen_and_run PASSED
3 passed in 30.04s
```

Existing tests unaffected (1290 passed, 3 skipped):
```
uv run pytest --ignore=tests/snapshots  # 1290 passed, 3 skipped
```

## Commands run

- `uv run ruff check tests/live_llm/` ✅
- `uv run ruff format tests/live_llm/ --check` ✅
- `uv run pytest --ignore=tests/snapshots -q` → 1290 passed, 3 skipped ✅
- `uv run pytest tests/live_llm/ -v` → 3 skipped (no flag) ✅
- `uv run pytest tests/live_llm/ --run-live-llm -v` → 3 passed ✅

## Other changes

- `Makefile`: add `test-live-llm` target
- `.gitignore`: add `.live-llm-results/`
- `AGENTS.md`: document live LLM test layer

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/live-llm-integration-tests
```