### PR TITLE
fix: add httpx[socks] dependency for SOCKS proxy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "pydantic>=2.7",
   "textual-autocomplete>=4.0.6",
   "pyperclip>=1.9.0",
-  "httpx>=0.25.0",
+  "httpx[socks]>=0.25.0",
   "textual-serve>=1.1.3",
   "streamingjson>=0.0.2",
 ]

--- a/tests/test_socks_proxy_support.py
+++ b/tests/test_socks_proxy_support.py
@@ -1,0 +1,48 @@
+"""Tests for SOCKS proxy support (issue #632).
+
+When a user has SOCKS proxy env vars set (e.g. all_proxy=socks5://...),
+httpx needs the socksio package to handle SOCKS proxy connections.
+Without it, importing litellm (via openhands-sdk) crashes at startup.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def test_socksio_is_installed():
+    """Verify that socksio is installed as part of httpx[socks]."""
+    import socksio  # noqa: F401
+
+
+def test_httpx_socks_extra_available():
+    """Verify httpx can create a client when SOCKS proxy env vars are set."""
+    import httpx
+
+    # Simulate a SOCKS proxy env var; the Client constructor should not raise
+    # ImportError for socksio. We use a non-routable address so no real
+    # connection is attempted.
+    client = httpx.Client(proxy="socks5://127.0.0.1:19999")
+    client.close()
+
+
+def test_import_with_socks_proxy_env(tmp_path):
+    """Ensure the CLI entrypoint can be imported when all_proxy is set to socks5."""
+    env = os.environ.copy()
+    env["all_proxy"] = "socks5://127.0.0.1:19999"
+    env["https_proxy"] = "socks5://127.0.0.1:19999"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import httpx; c = httpx.Client(); c.close(); print('ok')",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"Import failed with SOCKS proxy env vars set:\n{result.stderr}"
+    )
+    assert "ok" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1041,6 +1041,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.1"
@@ -1653,7 +1658,7 @@ version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "openhands-sdk" },
     { name = "openhands-tools" },
     { name = "openhands-workspace" },
@@ -1692,7 +1697,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.8.1,<0.9.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.25.0" },
     { name = "openhands-sdk", specifier = "==1.16.0" },
     { name = "openhands-tools", specifier = "==1.16.0" },
     { name = "openhands-workspace", specifier = "==1.11.1" },
@@ -5179,6 +5184,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
Changed `httpx>=0.25.0` to `httpx[socks]>=0.25.0` in `pyproject.toml` so that the `socksio` package is always installed alongside `httpx`.

## Why
Fixes #632

When users have SOCKS proxy environment variables set (e.g., `all_proxy=socks5://127.0.0.1:7897`), `httpx` needs the `socksio` package to handle SOCKS proxy connections. Without it, `litellm` (imported via `openhands-sdk`) crashes at startup with:

```
ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
Make sure to install httpx using \`pip install httpx[socks]\`.
```

The `httpx[socks]` extra installs `socksio`, enabling SOCKS proxy support.

## Root cause
The root cause is in the `openhands-sdk` package (`OpenHands/software-agent-sdk`), which depends on `httpx>=0.27.0` and `litellm`. At `litellm` import time, an `httpx.Client` is created at module level, and if SOCKS proxy env vars are set, `httpx` requires `socksio`. A separate PR has been opened on the SDK repo to fix it there as well: https://github.com/OpenHands/software-agent-sdk/pull/2664

## Changes
- `pyproject.toml`: `httpx>=0.25.0` → `httpx[socks]>=0.25.0`
- `uv.lock`: Updated to include `socksio v1.0.0`
- `tests/test_socks_proxy_support.py`: Added tests verifying socksio is installed and httpx works with SOCKS proxy env vars

## Commands run
- `make lint` ✅
- `make test` ✅ (1280 passed)

---
*This PR was created by an AI assistant (OpenHands) on behalf of @xingyaoww.*