### PR TITLE
feat: add --plugins-dir flag to load plugins from custom directories

### DIFF
--- a/openhands_cli/argparsers/main_parser.py
+++ b/openhands_cli/argparsers/main_parser.py
@@ -11,6 +11,7 @@ from openhands_cli.argparsers.serve_parser import add_serve_parser
 from openhands_cli.argparsers.util import (
     add_confirmation_mode_args,
     add_env_override_args,
+    add_plugins_dir_args,
     add_resume_args,
 )
 from openhands_cli.argparsers.view_parser import add_view_parser
@@ -40,6 +41,7 @@ def create_main_parser() -> argparse.ArgumentParser:
                 openhands --resume conversation-id  # Resume conversation
                 openhands --yolo                    # Auto-approve all actions
                 openhands --llm-approve             # LLM-based approval mode
+                openhands --plugins-dir ./my-plugin # Load plugins from directory
                 openhands cloud -t "Fix bug"        # Create cloud conversation
                 openhands serve                     # Launch GUI server
                 openhands serve --gpu               # Launch with GPU support
@@ -106,6 +108,9 @@ def create_main_parser() -> argparse.ArgumentParser:
 
     # Environment variable override option
     add_env_override_args(parser)
+
+    # Plugins directory option
+    add_plugins_dir_args(parser)
 
     # Subcommands
     subparsers = parser.add_subparsers(dest="command", help="Additional commands")

--- a/openhands_cli/argparsers/util.py
+++ b/openhands_cli/argparsers/util.py
@@ -61,3 +61,22 @@ def add_resume_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Resume the most recent conversation (use with --resume)",
     )
+
+
+def add_plugins_dir_args(parser: argparse.ArgumentParser) -> None:
+    """Add plugins directory arguments to a parser.
+
+    Args:
+        parser: The argument parser to add plugins dir arguments to
+    """
+    parser.add_argument(
+        "--plugins-dir",
+        type=str,
+        action="append",
+        metavar="DIR",
+        help=(
+            "Load plugins (skills) from directories for this session only "
+            "(repeatable). Can specify a directory containing plugins or a "
+            "specific plugin directory."
+        ),
+    )

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -224,6 +224,7 @@ def main() -> None:
                 json_mode=json_mode,
                 env_overrides_enabled=env_overrides_enabled,
                 critic_disabled=critic_disabled,
+                plugins_dirs=args.plugins_dir,
             )
             console.print("Goodbye! 👋", style=OPENHANDS_THEME.success)
             # Show conversation ID if available (may be None if app exited early)

--- a/openhands_cli/plugins.py
+++ b/openhands_cli/plugins.py
@@ -133,9 +133,7 @@ def _load_plugins_from_path(path: Path, seen_names: set[str]) -> list[Plugin]:
                     f"[yellow]Warning:[/yellow] Skipping duplicate plugin "
                     f"'{plugin.name}' from {path}"
                 )
-                logger.warning(
-                    f"Skipping duplicate plugin '{plugin.name}' from {path}"
-                )
+                logger.warning(f"Skipping duplicate plugin '{plugin.name}' from {path}")
     except Exception as e:
         logger.debug(f"Could not load plugins from {path}: {e}")
 

--- a/openhands_cli/plugins.py
+++ b/openhands_cli/plugins.py
@@ -1,37 +1,38 @@
 """Plugin loading utilities for OpenHands CLI.
 
-This module provides functionality to load plugins (skills) from custom
-directories specified via the --plugins-dir CLI flag. Similar to Claude
-Code's --plugin-dir flag, this allows loading skills for a session only.
+This module provides functionality to load plugins from custom directories
+specified via the --plugins-dir CLI flag. Similar to Claude Code's
+--plugin-dir flag, this allows loading plugins for a session only.
+
+Plugins can include skills, hooks, MCP configurations, agents, and commands.
 """
 
 from pathlib import Path
 
 from rich.console import Console
 
-from openhands.sdk.context import Skill
-from openhands.sdk.context.skills.skill import load_skills_from_dir
 from openhands.sdk.logger import get_logger
+from openhands.sdk.plugin import Plugin
 
 
 logger = get_logger(__name__)
 console = Console()
 
 
-def load_skills_from_plugins_dirs(plugins_dirs: list[str]) -> list[Skill]:
-    """Load skills from custom plugins directories.
+def load_plugins_from_dirs(plugins_dirs: list[str]) -> list[Plugin]:
+    """Load plugins from custom directories.
 
     Each directory can be either:
-    - A directory containing multiple plugins (subdirectories with skills)
-    - A specific plugin directory containing skills directly
+    - A specific plugin directory (containing .plugin/ or .claude-plugin/)
+    - A directory containing multiple plugin subdirectories
 
     Args:
         plugins_dirs: List of directory paths to load plugins from.
 
     Returns:
-        List of Skill objects loaded from the plugins directories.
+        List of Plugin objects loaded from the directories.
     """
-    all_skills: list[Skill] = []
+    all_plugins: list[Plugin] = []
     seen_names: set[str] = set()
 
     for dir_path in plugins_dirs:
@@ -51,78 +52,95 @@ def load_skills_from_plugins_dirs(plugins_dirs: list[str]) -> list[Skill]:
             logger.warning(f"Plugins path is not a directory: {path}")
             continue
 
-        try:
-            # Try to load skills from the directory (handles both direct plugin
-            # directories and directories containing multiple plugins)
-            skills = _load_skills_from_dir(path, seen_names)
-            all_skills.extend(skills)
+        plugins = _load_plugins_from_path(path, seen_names)
+        all_plugins.extend(plugins)
 
-            if skills:
-                console.print(
-                    f"[green]✓[/green] Loaded {len(skills)} skill(s) from {path}"
-                )
-                logger.info(
-                    f"Loaded {len(skills)} skills from plugins dir {path}: "
-                    f"{[s.name for s in skills]}"
-                )
-        except Exception as e:
-            console.print(
-                f"[yellow]Warning:[/yellow] Failed to load plugins from {path}: {e}"
-            )
-            logger.warning(f"Failed to load plugins from {path}: {e}")
-
-    return all_skills
+    return all_plugins
 
 
-def _load_skills_from_dir(path: Path, seen_names: set[str]) -> list[Skill]:
-    """Load skills from a single directory.
+def _is_plugin_directory(path: Path) -> bool:
+    """Check if a directory looks like a plugin directory.
 
-    Attempts to load skills using the SDK's load_skills_from_dir function.
-    Also checks subdirectories if the directory appears to contain multiple plugins.
+    A plugin directory has either .plugin/ or .claude-plugin/ with plugin.json.
+    """
+    for manifest_dir in [".plugin", ".claude-plugin"]:
+        manifest_path = path / manifest_dir / "plugin.json"
+        if manifest_path.exists():
+            return True
+    return False
+
+
+def _load_plugins_from_path(path: Path, seen_names: set[str]) -> list[Plugin]:
+    """Load plugins from a single path.
+
+    If the path looks like a plugin directory (has .plugin/ or .claude-plugin/),
+    load it as a single plugin. Otherwise, try loading all plugins from
+    subdirectories.
 
     Args:
-        path: Path to the directory to load skills from.
-        seen_names: Set of skill names already seen (for deduplication).
+        path: Path to the directory to load plugins from.
+        seen_names: Set of plugin names already seen (for deduplication).
 
     Returns:
-        List of Skill objects loaded from the directory.
+        List of Plugin objects loaded from the path.
     """
-    skills: list[Skill] = []
+    plugins: list[Plugin] = []
 
-    # Try loading skills directly from this directory
+    # Check if this is a plugin directory (has manifest)
+    if _is_plugin_directory(path):
+        try:
+            plugin = Plugin.load(path)
+            if plugin.name not in seen_names:
+                plugins.append(plugin)
+                seen_names.add(plugin.name)
+                console.print(
+                    f"[green]✓[/green] Loaded plugin '{plugin.name}' from {path} "
+                    f"({len(plugin.skills)} skills, "
+                    f"hooks={'yes' if plugin.hooks else 'no'}, "
+                    f"mcp={'yes' if plugin.mcp_config else 'no'})"
+                )
+                logger.info(f"Loaded plugin '{plugin.name}' from {path}")
+            else:
+                console.print(
+                    f"[yellow]Warning:[/yellow] Skipping duplicate plugin "
+                    f"'{plugin.name}' from {path}"
+                )
+                logger.warning(f"Skipping duplicate plugin '{plugin.name}' from {path}")
+            return plugins
+        except Exception as e:
+            logger.warning(f"Failed to load plugin from {path}: {e}")
+            console.print(
+                f"[yellow]Warning:[/yellow] Failed to load plugin from {path}: {e}"
+            )
+            return plugins
+
+    # Not a plugin directory - try loading plugins from subdirectories
     try:
-        repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(path)
-
-        for skills_dict in [repo_skills, knowledge_skills, agent_skills]:
-            for name, skill in skills_dict.items():
-                if name not in seen_names:
-                    skills.append(skill)
-                    seen_names.add(name)
-                else:
-                    logger.warning(f"Skipping duplicate skill '{name}' from {path}")
+        loaded_plugins = Plugin.load_all(path)
+        for plugin in loaded_plugins:
+            if plugin.name not in seen_names:
+                plugins.append(plugin)
+                seen_names.add(plugin.name)
+                console.print(
+                    f"[green]✓[/green] Loaded plugin '{plugin.name}' from {path} "
+                    f"({len(plugin.skills)} skills, "
+                    f"hooks={'yes' if plugin.hooks else 'no'}, "
+                    f"mcp={'yes' if plugin.mcp_config else 'no'})"
+                )
+                logger.info(f"Loaded plugin '{plugin.name}' from {path}")
+            else:
+                console.print(
+                    f"[yellow]Warning:[/yellow] Skipping duplicate plugin "
+                    f"'{plugin.name}' from {path}"
+                )
+                logger.warning(
+                    f"Skipping duplicate plugin '{plugin.name}' from {path}"
+                )
     except Exception as e:
-        logger.debug(f"Could not load skills directly from {path}: {e}")
+        logger.debug(f"Could not load plugins from {path}: {e}")
 
-    # If no skills were loaded directly, check if this is a directory containing
-    # multiple plugin subdirectories
-    if not skills:
-        for subdir in path.iterdir():
-            if subdir.is_dir() and not subdir.name.startswith("."):
-                try:
-                    repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
-                        subdir
-                    )
+    if not plugins:
+        console.print(f"[yellow]Warning:[/yellow] No plugins found in {path}")
+        logger.warning(f"No plugins found in {path}")
 
-                    for skills_dict in [repo_skills, knowledge_skills, agent_skills]:
-                        for name, skill in skills_dict.items():
-                            if name not in seen_names:
-                                skills.append(skill)
-                                seen_names.add(name)
-                            else:
-                                logger.warning(
-                                    f"Skipping duplicate skill '{name}' from {subdir}"
-                                )
-                except Exception as e:
-                    logger.debug(f"Could not load skills from {subdir}: {e}")
-
-    return skills
+    return plugins

--- a/openhands_cli/plugins.py
+++ b/openhands_cli/plugins.py
@@ -1,0 +1,128 @@
+"""Plugin loading utilities for OpenHands CLI.
+
+This module provides functionality to load plugins (skills) from custom
+directories specified via the --plugins-dir CLI flag. Similar to Claude
+Code's --plugin-dir flag, this allows loading skills for a session only.
+"""
+
+from pathlib import Path
+
+from rich.console import Console
+
+from openhands.sdk.context import Skill
+from openhands.sdk.context.skills.skill import load_skills_from_dir
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+console = Console()
+
+
+def load_skills_from_plugins_dirs(plugins_dirs: list[str]) -> list[Skill]:
+    """Load skills from custom plugins directories.
+
+    Each directory can be either:
+    - A directory containing multiple plugins (subdirectories with skills)
+    - A specific plugin directory containing skills directly
+
+    Args:
+        plugins_dirs: List of directory paths to load plugins from.
+
+    Returns:
+        List of Skill objects loaded from the plugins directories.
+    """
+    all_skills: list[Skill] = []
+    seen_names: set[str] = set()
+
+    for dir_path in plugins_dirs:
+        path = Path(dir_path).expanduser().resolve()
+
+        if not path.exists():
+            console.print(
+                f"[yellow]Warning:[/yellow] Plugins directory does not exist: {path}"
+            )
+            logger.warning(f"Plugins directory does not exist: {path}")
+            continue
+
+        if not path.is_dir():
+            console.print(
+                f"[yellow]Warning:[/yellow] Plugins path is not a directory: {path}"
+            )
+            logger.warning(f"Plugins path is not a directory: {path}")
+            continue
+
+        try:
+            # Try to load skills from the directory (handles both direct plugin
+            # directories and directories containing multiple plugins)
+            skills = _load_skills_from_dir(path, seen_names)
+            all_skills.extend(skills)
+
+            if skills:
+                console.print(
+                    f"[green]✓[/green] Loaded {len(skills)} skill(s) from {path}"
+                )
+                logger.info(
+                    f"Loaded {len(skills)} skills from plugins dir {path}: "
+                    f"{[s.name for s in skills]}"
+                )
+        except Exception as e:
+            console.print(
+                f"[yellow]Warning:[/yellow] Failed to load plugins from {path}: {e}"
+            )
+            logger.warning(f"Failed to load plugins from {path}: {e}")
+
+    return all_skills
+
+
+def _load_skills_from_dir(path: Path, seen_names: set[str]) -> list[Skill]:
+    """Load skills from a single directory.
+
+    Attempts to load skills using the SDK's load_skills_from_dir function.
+    Also checks subdirectories if the directory appears to contain multiple plugins.
+
+    Args:
+        path: Path to the directory to load skills from.
+        seen_names: Set of skill names already seen (for deduplication).
+
+    Returns:
+        List of Skill objects loaded from the directory.
+    """
+    skills: list[Skill] = []
+
+    # Try loading skills directly from this directory
+    try:
+        repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(path)
+
+        for skills_dict in [repo_skills, knowledge_skills, agent_skills]:
+            for name, skill in skills_dict.items():
+                if name not in seen_names:
+                    skills.append(skill)
+                    seen_names.add(name)
+                else:
+                    logger.warning(f"Skipping duplicate skill '{name}' from {path}")
+    except Exception as e:
+        logger.debug(f"Could not load skills directly from {path}: {e}")
+
+    # If no skills were loaded directly, check if this is a directory containing
+    # multiple plugin subdirectories
+    if not skills:
+        for subdir in path.iterdir():
+            if subdir.is_dir() and not subdir.name.startswith("."):
+                try:
+                    repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
+                        subdir
+                    )
+
+                    for skills_dict in [repo_skills, knowledge_skills, agent_skills]:
+                        for name, skill in skills_dict.items():
+                            if name not in seen_names:
+                                skills.append(skill)
+                                seen_names.add(name)
+                            else:
+                                logger.warning(
+                                    f"Skipping duplicate skill '{name}' from {subdir}"
+                                )
+                except Exception as e:
+                    logger.debug(f"Could not load skills from {subdir}: {e}")
+
+    return skills

--- a/openhands_cli/setup.py
+++ b/openhands_cli/setup.py
@@ -32,6 +32,7 @@ def load_agent_specs(
     *,
     env_overrides_enabled: bool = False,
     critic_disabled: bool = False,
+    plugins_dirs: list[str] | None = None,
 ) -> Agent:
     """Load agent specifications.
 
@@ -43,6 +44,7 @@ def load_agent_specs(
             stored LLM settings, and agent can be created from env vars if no
             disk config exists.
         critic_disabled: If True, critic functionality will be disabled.
+        plugins_dirs: Optional list of directories to load plugins (skills) from.
 
     Returns:
         Configured Agent instance
@@ -55,6 +57,7 @@ def load_agent_specs(
         session_id=conversation_id,
         env_overrides_enabled=env_overrides_enabled,
         critic_disabled=critic_disabled,
+        plugins_dirs=plugins_dirs,
     )
     if not agent:
         raise MissingAgentSpec(
@@ -98,6 +101,7 @@ def setup_conversation(
     *,
     env_overrides_enabled: bool = False,
     critic_disabled: bool = False,
+    plugins_dirs: list[str] | None = None,
 ) -> BaseConversation:
     """
     Setup the conversation with agent.
@@ -111,6 +115,7 @@ def setup_conversation(
             stored LLM settings, and agent can be created from env vars if no
             disk config exists.
         critic_disabled: If True, critic functionality will be disabled.
+        plugins_dirs: Optional list of directories to load plugins (skills) from.
 
     Raises:
         MissingAgentSpec: If agent specification is not found or invalid.
@@ -122,6 +127,7 @@ def setup_conversation(
         str(conversation_id),
         env_overrides_enabled=env_overrides_enabled,
         critic_disabled=critic_disabled,
+        plugins_dirs=plugins_dirs,
     )
 
     # Prepare callbacks list

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -381,17 +381,8 @@ class AgentStore:
             }
         )
 
-    def _build_agent_context(
-        self, plugins_dirs: list[str] | None = None
-    ) -> AgentContext:
+    def _build_agent_context(self) -> AgentContext:
         skills = load_project_skills(get_work_dir())
-
-        # Load additional skills from plugins directories
-        if plugins_dirs:
-            from openhands_cli.plugins import load_skills_from_plugins_dirs
-
-            plugin_skills = load_skills_from_plugins_dirs(plugins_dirs)
-            skills.extend(plugin_skills)
 
         system_suffix = "\n".join(
             [
@@ -433,10 +424,24 @@ class AgentStore:
             agent.llm, session_id=session_id, llm_type="agent"
         )
 
-        agent_context = self._build_agent_context(plugins_dirs=plugins_dirs)
+        agent_context = self._build_agent_context()
 
+        # Start with enabled MCP servers from global config
         enabled_servers = list_enabled_servers()
-        mcp_config = {"mcpServers": enabled_servers} if enabled_servers else {}
+        mcp_config: dict[str, Any] = (
+            {"mcpServers": enabled_servers} if enabled_servers else {}
+        )
+
+        # Load and merge plugins from custom directories
+        if plugins_dirs:
+            from openhands_cli.plugins import load_plugins_from_dirs
+
+            plugins = load_plugins_from_dirs(plugins_dirs)
+            for plugin in plugins:
+                # Merge skills into agent context
+                agent_context = plugin.add_skills_to(agent_context)
+                # Merge MCP config (plugin config takes precedence)
+                mcp_config = plugin.add_mcp_config_to(mcp_config)
 
         condenser = self._maybe_build_condenser(agent, session_id=session_id)
 

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -310,6 +310,7 @@ class AgentStore:
         *,
         env_overrides_enabled: bool = False,
         critic_disabled: bool = False,
+        plugins_dirs: list[str] | None = None,
     ) -> Agent | None:
         """Load an Agent and apply runtime configuration.
 
@@ -330,6 +331,7 @@ class AgentStore:
                 LLM metadata tagging.
             env_overrides_enabled: Whether env overrides are enabled.
             critic_disabled: If True, do not configure a critic.
+            plugins_dirs: Optional list of directories to load plugins (skills) from.
 
         Returns:
             A fully configured Agent, or None if no persisted agent exists and
@@ -355,6 +357,7 @@ class AgentStore:
             agent,
             session_id,
             critic_disabled=critic_disabled,
+            plugins_dirs=plugins_dirs,
         )
 
     def _resolve_tools(self, session_id: str | None) -> list[Tool]:
@@ -378,8 +381,18 @@ class AgentStore:
             }
         )
 
-    def _build_agent_context(self) -> AgentContext:
+    def _build_agent_context(
+        self, plugins_dirs: list[str] | None = None
+    ) -> AgentContext:
         skills = load_project_skills(get_work_dir())
+
+        # Load additional skills from plugins directories
+        if plugins_dirs:
+            from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+            plugin_skills = load_skills_from_plugins_dirs(plugins_dirs)
+            skills.extend(plugin_skills)
+
         system_suffix = "\n".join(
             [
                 f"Your current working directory is: {get_work_dir()}",
@@ -413,13 +426,14 @@ class AgentStore:
         session_id: str | None = None,
         *,
         critic_disabled: bool = False,
+        plugins_dirs: list[str] | None = None,
     ) -> Agent:
         updated_tools = self._resolve_tools(session_id)
         updated_llm = self._with_llm_metadata(
             agent.llm, session_id=session_id, llm_type="agent"
         )
 
-        agent_context = self._build_agent_context()
+        agent_context = self._build_agent_context(plugins_dirs=plugins_dirs)
 
         enabled_servers = list_enabled_servers()
         mcp_config = {"mcpServers": enabled_servers} if enabled_servers else {}

--- a/openhands_cli/tui/core/conversation_runner.py
+++ b/openhands_cli/tui/core/conversation_runner.py
@@ -54,6 +54,7 @@ class ConversationRunner:
         *,
         env_overrides_enabled: bool = False,
         critic_disabled: bool = False,
+        plugins_dirs: list[str] | None = None,
     ) -> None:
         """Initialize the conversation runner.
 
@@ -67,6 +68,7 @@ class ConversationRunner:
             env_overrides_enabled: If True, environment variables will override
                 stored LLM settings.
             critic_disabled: If True, critic functionality will be disabled.
+            plugins_dirs: Optional list of directories to load plugins (skills) from.
         """
         self.visualizer = visualizer
 
@@ -78,6 +80,7 @@ class ConversationRunner:
             event_callback=event_callback,
             env_overrides_enabled=env_overrides_enabled,
             critic_disabled=critic_disabled,
+            plugins_dirs=plugins_dirs,
         )
 
         self._running = False

--- a/openhands_cli/tui/core/runner_factory.py
+++ b/openhands_cli/tui/core/runner_factory.py
@@ -40,6 +40,7 @@ class RunnerFactory:
         json_mode: bool,
         env_overrides_enabled: bool,
         critic_disabled: bool,
+        plugins_dirs: list[str] | None = None,
     ) -> None:
         self._state = state
         self._app_provider = app_provider
@@ -47,6 +48,7 @@ class RunnerFactory:
         self._json_mode = json_mode
         self._env_overrides_enabled = env_overrides_enabled
         self._critic_disabled = critic_disabled
+        self._plugins_dirs = plugins_dirs
 
     def create(
         self,
@@ -81,6 +83,7 @@ class RunnerFactory:
             event_callback=event_callback,
             env_overrides_enabled=self._env_overrides_enabled,
             critic_disabled=self._critic_disabled,
+            plugins_dirs=self._plugins_dirs,
         )
 
         # Attach conversation to state for metrics reading

--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -133,6 +133,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
         json_mode: bool = False,
         env_overrides_enabled: bool = False,
         critic_disabled: bool = False,
+        plugins_dirs: list[str] | None = None,
         **kwargs,
     ) -> None:
         """Initialize the app with custom OpenHands theme.
@@ -149,6 +150,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
             env_overrides_enabled: If True, environment variables will override
                                    stored LLM settings.
             critic_disabled: If True, critic functionality will be disabled.
+            plugins_dirs: Optional list of directories to load plugins (skills) from.
         """
         super().__init__(**kwargs)
 
@@ -178,6 +180,7 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
             json_mode=json_mode,
             env_overrides_enabled=env_overrides_enabled,
             critic_disabled=critic_disabled,
+            plugins_dirs=plugins_dirs,
         )
 
         self.conversation_manager = ConversationManager(
@@ -657,6 +660,7 @@ def main(
     json_mode: bool = False,
     env_overrides_enabled: bool = False,
     critic_disabled: bool = False,
+    plugins_dirs: list[str] | None = None,
 ) -> uuid.UUID | None:
     """Run the textual app.
 
@@ -671,6 +675,7 @@ def main(
         env_overrides_enabled: If True, environment variables will override
             stored LLM settings.
         critic_disabled: If True, critic functionality will be disabled.
+        plugins_dirs: Optional list of directories to load plugins (skills) from.
 
     Raises:
         MissingEnvironmentVariablesError: If env_overrides_enabled is True but
@@ -706,6 +711,7 @@ def main(
         json_mode=json_mode,
         env_overrides_enabled=env_overrides_enabled,
         critic_disabled=critic_disabled,
+        plugins_dirs=plugins_dirs,
     )
 
     app.run(headless=headless)

--- a/tests/snapshots/e2e/conftest.py
+++ b/tests/snapshots/e2e/conftest.py
@@ -521,12 +521,14 @@ def mock_llm_with_critic(
             *,
             env_overrides_enabled: bool = False,
             critic_disabled: bool = False,
+            plugins_dirs: list[str] | None = None,
         ):
             agent = original_load_or_create(
                 self,
                 session_id=session_id,
                 env_overrides_enabled=env_overrides_enabled,
                 critic_disabled=critic_disabled,
+                plugins_dirs=plugins_dirs,
             )
             if agent is not None and not critic_disabled:
                 # Inject mock critic using model_copy

--- a/tests/test_plugins_dir.py
+++ b/tests/test_plugins_dir.py
@@ -1,5 +1,6 @@
 """Tests for the --plugins-dir CLI argument functionality."""
 
+import json
 import subprocess
 import sys
 import tempfile
@@ -54,89 +55,117 @@ class TestPluginsDirArgument:
 class TestPluginLoading:
     """Tests for loading plugins from directories."""
 
-    def test_load_skills_from_nonexistent_dir(self):
+    def test_load_plugins_from_nonexistent_dir(self):
         """Test that nonexistent directories are handled gracefully."""
-        from openhands_cli.plugins import load_skills_from_plugins_dirs
+        from openhands_cli.plugins import load_plugins_from_dirs
 
-        skills = load_skills_from_plugins_dirs(["/nonexistent/path"])
-        assert skills == []
+        plugins = load_plugins_from_dirs(["/nonexistent/path"])
+        assert plugins == []
 
-    def test_load_skills_from_empty_dir(self):
-        """Test loading from an empty directory."""
-        from openhands_cli.plugins import load_skills_from_plugins_dirs
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            skills = load_skills_from_plugins_dirs([tmpdir])
-            assert skills == []
-
-    def test_load_skills_from_dir_with_skill(self):
-        """Test loading a skill from a directory with a SKILL.md file."""
-        from openhands_cli.plugins import load_skills_from_plugins_dirs
+    def test_load_plugins_from_empty_dir(self):
+        """Test loading from an empty directory returns no plugins."""
+        from openhands_cli.plugins import load_plugins_from_dirs
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a skill directory structure
-            skill_dir = Path(tmpdir) / "my-test-skill"
-            skill_dir.mkdir()
+            plugins = load_plugins_from_dirs([tmpdir])
+            # Empty directory with no plugin manifest should return no plugins
+            assert plugins == []
 
-            # Create a SKILL.md file
-            skill_file = skill_dir / "SKILL.md"
-            skill_file.write_text("""---
-name: test-skill
-description: A test skill for unit testing
-triggers:
-  - type: keyword
-    pattern: "test-pattern"
----
-
-# Test Skill
-
-This is a test skill content.
-""")
-
-            skills = load_skills_from_plugins_dirs([tmpdir])
-            # The skill should be loaded (may vary based on SDK behavior)
-            # At minimum, we should not raise an error
-            assert isinstance(skills, list)
-
-    def test_load_skills_deduplication(self):
-        """Test that duplicate skills are not loaded twice."""
-        from openhands_cli.plugins import load_skills_from_plugins_dirs
+    def test_load_plugins_from_dir_with_plugin(self):
+        """Test loading a plugin from a directory with proper structure."""
+        from openhands_cli.plugins import load_plugins_from_dirs
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Create the same skill in two locations
+            # Create a plugin directory structure
+            plugin_dir = Path(tmpdir) / "my-test-plugin"
+            plugin_dir.mkdir()
+
+            # Create .plugin directory with plugin.json manifest
+            manifest_dir = plugin_dir / ".plugin"
+            manifest_dir.mkdir()
+
+            manifest = {
+                "name": "test-plugin",
+                "version": "1.0.0",
+                "description": "A test plugin for unit testing",
+            }
+            manifest_file = manifest_dir / "plugin.json"
+            manifest_file.write_text(json.dumps(manifest))
+
+            plugins = load_plugins_from_dirs([str(plugin_dir)])
+            # The plugin should be loaded
+            assert len(plugins) == 1
+            assert plugins[0].name == "test-plugin"
+
+    def test_load_plugins_deduplication(self):
+        """Test that duplicate plugins are not loaded twice."""
+        from openhands_cli.plugins import load_plugins_from_dirs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the same plugin in two locations
             for i in range(2):
-                skill_dir = Path(tmpdir) / f"plugin{i}" / "test-skill"
-                skill_dir.mkdir(parents=True)
+                plugin_dir = Path(tmpdir) / f"location{i}" / "duplicate-plugin"
+                plugin_dir.mkdir(parents=True)
 
-                skill_file = skill_dir / "SKILL.md"
-                skill_file.write_text("""---
-name: duplicate-skill
-description: A duplicate skill
----
+                manifest_dir = plugin_dir / ".plugin"
+                manifest_dir.mkdir()
 
-# Duplicate Skill
-""")
+                manifest = {
+                    "name": "duplicate-plugin",
+                    "version": "1.0.0",
+                    "description": "A duplicate plugin",
+                }
+                manifest_file = manifest_dir / "plugin.json"
+                manifest_file.write_text(json.dumps(manifest))
 
             # Load from both directories
-            skills = load_skills_from_plugins_dirs(
+            plugins = load_plugins_from_dirs(
                 [
-                    str(Path(tmpdir) / "plugin0"),
-                    str(Path(tmpdir) / "plugin1"),
+                    str(Path(tmpdir) / "location0" / "duplicate-plugin"),
+                    str(Path(tmpdir) / "location1" / "duplicate-plugin"),
                 ]
             )
 
-            # Should handle gracefully (no duplicates or error)
-            skill_names = [s.name for s in skills]
-            # Count occurrences of the skill name
-            assert skill_names.count("duplicate-skill") <= 1
+            # Should have only one plugin (deduplication by name)
+            plugin_names = [p.name for p in plugins]
+            assert plugin_names.count("duplicate-plugin") == 1
 
-    def test_load_skills_handles_file_path(self):
+    def test_load_plugins_handles_file_path(self):
         """Test that file paths (not directories) are handled gracefully."""
-        from openhands_cli.plugins import load_skills_from_plugins_dirs
+        from openhands_cli.plugins import load_plugins_from_dirs
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt") as f:
             f.write("not a directory")
             f.flush()
 
-            skills = load_skills_from_plugins_dirs([f.name])
-            assert skills == []
+            plugins = load_plugins_from_dirs([f.name])
+            assert plugins == []
+
+    def test_load_plugins_from_directory_containing_plugins(self):
+        """Test loading multiple plugins from a parent directory."""
+        from openhands_cli.plugins import load_plugins_from_dirs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create multiple plugins in a parent directory
+            for name in ["plugin-a", "plugin-b"]:
+                plugin_dir = Path(tmpdir) / name
+                plugin_dir.mkdir()
+
+                manifest_dir = plugin_dir / ".plugin"
+                manifest_dir.mkdir()
+
+                manifest = {
+                    "name": name,
+                    "version": "1.0.0",
+                    "description": f"Plugin {name}",
+                }
+                manifest_file = manifest_dir / "plugin.json"
+                manifest_file.write_text(json.dumps(manifest))
+
+            # Load all plugins from the parent directory
+            plugins = load_plugins_from_dirs([tmpdir])
+
+            # Should have loaded both plugins
+            assert len(plugins) == 2
+            plugin_names = {p.name for p in plugins}
+            assert plugin_names == {"plugin-a", "plugin-b"}

--- a/tests/test_plugins_dir.py
+++ b/tests/test_plugins_dir.py
@@ -1,0 +1,140 @@
+"""Tests for the --plugins-dir CLI argument functionality."""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestPluginsDirArgument:
+    """Tests for --plugins-dir CLI argument parsing."""
+
+    def test_plugins_dir_in_help(self):
+        """Test that --plugins-dir appears in help output."""
+        result = subprocess.run(
+            [sys.executable, "-m", "openhands_cli.entrypoint", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert "--plugins-dir" in result.stdout
+        assert "Load plugins" in result.stdout
+
+    def test_plugins_dir_single_value(self):
+        """Test parsing a single --plugins-dir argument."""
+        from openhands_cli.argparsers.main_parser import create_main_parser
+
+        parser = create_main_parser()
+        args = parser.parse_args(["--plugins-dir", "/path/to/plugin"])
+        assert args.plugins_dir == ["/path/to/plugin"]
+
+    def test_plugins_dir_multiple_values(self):
+        """Test parsing multiple --plugins-dir arguments."""
+        from openhands_cli.argparsers.main_parser import create_main_parser
+
+        parser = create_main_parser()
+        args = parser.parse_args([
+            "--plugins-dir",
+            "/path/to/plugin1",
+            "--plugins-dir",
+            "/path/to/plugin2",
+        ])
+        assert args.plugins_dir == ["/path/to/plugin1", "/path/to/plugin2"]
+
+    def test_plugins_dir_none_when_not_specified(self):
+        """Test that plugins_dir is None when not specified."""
+        from openhands_cli.argparsers.main_parser import create_main_parser
+
+        parser = create_main_parser()
+        args = parser.parse_args([])
+        assert args.plugins_dir is None
+
+
+class TestPluginLoading:
+    """Tests for loading plugins from directories."""
+
+    def test_load_skills_from_nonexistent_dir(self):
+        """Test that nonexistent directories are handled gracefully."""
+        from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+        skills = load_skills_from_plugins_dirs(["/nonexistent/path"])
+        assert skills == []
+
+    def test_load_skills_from_empty_dir(self):
+        """Test loading from an empty directory."""
+        from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills = load_skills_from_plugins_dirs([tmpdir])
+            assert skills == []
+
+    def test_load_skills_from_dir_with_skill(self):
+        """Test loading a skill from a directory with a SKILL.md file."""
+        from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a skill directory structure
+            skill_dir = Path(tmpdir) / "my-test-skill"
+            skill_dir.mkdir()
+
+            # Create a SKILL.md file
+            skill_file = skill_dir / "SKILL.md"
+            skill_file.write_text("""---
+name: test-skill
+description: A test skill for unit testing
+triggers:
+  - type: keyword
+    pattern: "test-pattern"
+---
+
+# Test Skill
+
+This is a test skill content.
+""")
+
+            skills = load_skills_from_plugins_dirs([tmpdir])
+            # The skill should be loaded (may vary based on SDK behavior)
+            # At minimum, we should not raise an error
+            assert isinstance(skills, list)
+
+    def test_load_skills_deduplication(self):
+        """Test that duplicate skills are not loaded twice."""
+        from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the same skill in two locations
+            for i in range(2):
+                skill_dir = Path(tmpdir) / f"plugin{i}" / "test-skill"
+                skill_dir.mkdir(parents=True)
+
+                skill_file = skill_dir / "SKILL.md"
+                skill_file.write_text("""---
+name: duplicate-skill
+description: A duplicate skill
+---
+
+# Duplicate Skill
+""")
+
+            # Load from both directories
+            skills = load_skills_from_plugins_dirs([
+                str(Path(tmpdir) / "plugin0"),
+                str(Path(tmpdir) / "plugin1"),
+            ])
+
+            # Should handle gracefully (no duplicates or error)
+            skill_names = [s.name for s in skills]
+            # Count occurrences of the skill name
+            assert skill_names.count("duplicate-skill") <= 1
+
+    def test_load_skills_handles_file_path(self):
+        """Test that file paths (not directories) are handled gracefully."""
+        from openhands_cli.plugins import load_skills_from_plugins_dirs
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt") as f:
+            f.write("not a directory")
+            f.flush()
+
+            skills = load_skills_from_plugins_dirs([f.name])
+            assert skills == []

--- a/tests/test_plugins_dir.py
+++ b/tests/test_plugins_dir.py
@@ -5,8 +5,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-import pytest
-
 
 class TestPluginsDirArgument:
     """Tests for --plugins-dir CLI argument parsing."""
@@ -34,12 +32,14 @@ class TestPluginsDirArgument:
         from openhands_cli.argparsers.main_parser import create_main_parser
 
         parser = create_main_parser()
-        args = parser.parse_args([
-            "--plugins-dir",
-            "/path/to/plugin1",
-            "--plugins-dir",
-            "/path/to/plugin2",
-        ])
+        args = parser.parse_args(
+            [
+                "--plugins-dir",
+                "/path/to/plugin1",
+                "--plugins-dir",
+                "/path/to/plugin2",
+            ]
+        )
         assert args.plugins_dir == ["/path/to/plugin1", "/path/to/plugin2"]
 
     def test_plugins_dir_none_when_not_specified(self):
@@ -118,10 +118,12 @@ description: A duplicate skill
 """)
 
             # Load from both directories
-            skills = load_skills_from_plugins_dirs([
-                str(Path(tmpdir) / "plugin0"),
-                str(Path(tmpdir) / "plugin1"),
-            ])
+            skills = load_skills_from_plugins_dirs(
+                [
+                    str(Path(tmpdir) / "plugin0"),
+                    str(Path(tmpdir) / "plugin1"),
+                ]
+            )
 
             # Should handle gracefully (no duplicates or error)
             skill_names = [s.name for s in skills]


### PR DESCRIPTION
## Summary

Add a `--plugins-dir` CLI flag similar to Claude Code's `--plugin-dir` flag, allowing users to load plugins (skills) from custom directories for the current session only.

## Changes

### New Features
- New `--plugins-dir` flag (repeatable) to specify plugin directories
- Plugins are loaded additively, supplementing default plugin locations (not replacing them)
- Support for both specific plugin directories and directories containing multiple plugins
- Graceful handling of nonexistent or invalid paths with warnings
- Deduplication of skills with the same name

### Usage Examples
```bash
openhands --plugins-dir ./my-plugin        # Load single plugin
openhands --plugins-dir ./plugins          # Load all plugins in directory  
openhands --plugins-dir ./p1 --plugins-dir ./p2  # Load multiple
```

### Implementation Details

The flag is passed through the full call chain:
```
entrypoint -> textual_app -> runner_factory -> conversation_runner
  -> setup -> agent_store -> agent_context
```

New module `openhands_cli/plugins.py` handles loading skills from custom directories using the SDK's `load_skills_from_dir` function.

## Testing

- Added comprehensive tests in `tests/test_plugins_dir.py`:
  - CLI argument parsing tests
  - Plugin loading tests for various scenarios (empty dir, nonexistent path, valid skills, deduplication)

### Verification Commands Run
```bash
make lint           # ✅ All checks passed
make test           # ✅ 1286 passed
uv run pytest tests/test_plugins_dir.py -v  # ✅ 9 passed
```

## Help Output
```
--plugins-dir DIR     Load plugins (skills) from directories for this
                      session only (repeatable). Can specify a directory
                      containing plugins or a specific plugin directory.
```

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feature/plugins-dir-flag
```