### PR TITLE
fix: dismiss critic feedback widget when new events arrive (#641)

### DIFF
--- a/openhands_cli/tui/modals/exit_modal.tcss
+++ b/openhands_cli/tui/modals/exit_modal.tcss
@@ -25,7 +25,7 @@ SwitchConversationModal {
     padding: 2 0;
 }
 
-Button {
+#dialog Button {
     width: 100%;
     height: 3;
     margin: 0 1;

--- a/openhands_cli/tui/widgets/richlog_visualizer.py
+++ b/openhands_cli/tui/widgets/richlog_visualizer.py
@@ -267,6 +267,10 @@ class ConversationVisualizer(ConversationVisualizerBase):
 
     def on_event(self, event: Event) -> None:
         """Main event handler that creates widgets for events."""
+        # Dismiss any pending critic feedback widgets when new events arrive,
+        # since the agent has continued working (user didn't interact with them)
+        self._run_on_main_thread(self._dismiss_pending_feedback_widgets)
+
         # Check for TaskTrackerObservation to update/open the plan panel
         if isinstance(event, ObservationEvent) and isinstance(
             event.observation, TaskTrackerObservation

--- a/tests/snapshots/__snapshots__/test_critic_feedback_snapshots/TestCriticFeedbackWidgetSnapshots.test_critic_feedback_widget_inside_vertical_scroll.svg
+++ b/tests/snapshots/__snapshots__/test_critic_feedback_snapshots/TestCriticFeedbackWidgetSnapshots.test_critic_feedback_widget_inside_vertical_scroll.svg
@@ -1,0 +1,138 @@
+<svg class="rich-terminal" viewBox="0 0 1238 538.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-r1 { fill: #c5c8c6 }
+.terminal-r2 { fill: #ffffff }
+.terminal-r3 { fill: #ffffff;font-weight: bold }
+.terminal-r4 { fill: #b3b3b3 }
+.terminal-r5 { fill: #4e4e4e }
+.terminal-r6 { fill: #277dff;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1219.0" height="487.0" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1220" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1220" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="536" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">CriticFeedbackInScrollApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#222222" x="0" y="1.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="12.2" y="25.9" width="536.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="549" y="25.9" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="50.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="74.7" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="12.2" y="99.1" width="780.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="793" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="805.2" y="99.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="927.2" y="99.1" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="12.2" y="123.5" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1207.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="24.4" y="147.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="195.2" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="231.8" y="147.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="402.6" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="439.2" y="147.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="597.8" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="671" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="780.8" y="147.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="854" y="147.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1012.6" y="147.9" width="207.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="172.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="196.7" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="221.1" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="245.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="269.9" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="294.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="318.7" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="343.1" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="367.5" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="391.9" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="416.3" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="440.7" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="0" y="465.1" width="1073.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1073.6" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1085.8" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1110.2" y="465.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#222222" x="1207.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r1" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r2" x="12.2" y="44.4" textLength="536.8" clip-path="url(#terminal-line-1)">Sample&#160;conversation&#160;content&#160;above&#160;the&#160;widget</text><text class="terminal-r1" x="1220" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r1" x="1220" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r1" x="1220" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r3" x="12.2" y="117.6" textLength="780.8" clip-path="url(#terminal-line-4)">Does&#160;the&#160;critic&#x27;s&#160;success&#160;prediction&#160;align&#160;with&#160;your&#160;perception?</text><text class="terminal-r4" x="805.2" y="117.6" textLength="122" clip-path="url(#terminal-line-4)">(Optional)</text><text class="terminal-r1" x="1220" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r1" x="1220" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r3" x="24.4" y="166.4" textLength="170.8" clip-path="url(#terminal-line-6)">&#160;[1]&#160;Accurate&#160;</text><text class="terminal-r3" x="231.8" y="166.4" textLength="170.8" clip-path="url(#terminal-line-6)">&#160;[2]&#160;Too&#160;high&#160;</text><text class="terminal-r3" x="439.2" y="166.4" textLength="158.6" clip-path="url(#terminal-line-6)">&#160;[3]&#160;Too&#160;low&#160;</text><text class="terminal-r3" x="671" y="166.4" textLength="109.8" clip-path="url(#terminal-line-6)">&#160;[4]&#160;N/A&#160;</text><text class="terminal-r3" x="854" y="166.4" textLength="158.6" clip-path="url(#terminal-line-6)">&#160;[0]&#160;Dismiss&#160;</text><text class="terminal-r1" x="1220" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r1" x="1220" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r1" x="1220" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r1" x="1220" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r1" x="1220" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r1" x="1220" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r1" x="1220" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r1" x="1220" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r1" x="1220" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r1" x="1220" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r1" x="1220" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r1" x="1220" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r1" x="1220" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r5" x="1073.6" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">▏</text><text class="terminal-r6" x="1085.8" y="483.6" textLength="24.4" clip-path="url(#terminal-line-19)">^p</text><text class="terminal-r2" x="1110.2" y="483.6" textLength="97.6" clip-path="url(#terminal-line-19)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/snapshots/test_critic_feedback_snapshots.py
+++ b/tests/snapshots/test_critic_feedback_snapshots.py
@@ -13,7 +13,7 @@ from typing import ClassVar
 from unittest.mock import MagicMock
 
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Button, Footer, Static
 
 from openhands_cli.theme import OPENHANDS_THEME
@@ -124,3 +124,50 @@ class TestCriticFeedbackWidgetSnapshots:
             CriticFeedbackTestApp(),
             terminal_size=(100, 20),
         )
+
+    def test_critic_feedback_widget_inside_vertical_scroll(self, snap_compare):
+        """Snapshot test: feedback widget inside VerticalScroll (real app context).
+
+        In the real app, CriticFeedbackWidget is mounted inside a VerticalScroll
+        container. This test reproduces the layout context to verify all 5 buttons
+        are visible.
+
+        Relates to: https://github.com/OpenHands/OpenHands-CLI/issues/641
+        """
+
+        class CriticFeedbackInScrollApp(App):
+            CSS = """
+            Screen {
+                background: $background;
+            }
+            #scroll_view {
+                width: 100%;
+                height: 1fr;
+            }
+            #content {
+                width: 100%;
+                height: auto;
+                padding: 1;
+            }
+            """
+
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.register_theme(OPENHANDS_THEME)
+                self.theme = OPENHANDS_THEME.name
+
+            def compose(self) -> ComposeResult:
+                with VerticalScroll(id="scroll_view"):
+                    yield Static(
+                        "Sample conversation content above the widget",
+                        id="content",
+                    )
+                    yield MockCriticFeedbackWidget()
+                yield Footer()
+
+        assert snap_compare(
+            CriticFeedbackInScrollApp(),
+            terminal_size=(100, 20),
+        )
+
+

--- a/tests/snapshots/test_critic_feedback_snapshots.py
+++ b/tests/snapshots/test_critic_feedback_snapshots.py
@@ -169,5 +169,3 @@ class TestCriticFeedbackWidgetSnapshots:
             CriticFeedbackInScrollApp(),
             terminal_size=(100, 20),
         )
-
-

--- a/tests/tui/modals/test_exit_modal.py
+++ b/tests/tui/modals/test_exit_modal.py
@@ -1,10 +1,51 @@
 """Tests for exit confirmation modal functionality."""
 
+import re
+from pathlib import Path
 from unittest import mock
 
 from textual.widgets import Button
 
 from openhands_cli.tui.modals.exit_modal import ExitConfirmationModal
+
+# Path to exit modal TCSS relative to the modal module
+EXIT_MODAL_TCSS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "openhands_cli"
+    / "tui"
+    / "modals"
+    / "exit_modal.tcss"
+)
+
+
+class TestExitModalCssScoping:
+    """Tests that exit modal CSS doesn't leak global styles.
+
+    Regression test for GitHub issue #641: an unscoped `Button { width: 100%; }`
+    rule in exit_modal.tcss was overriding CriticFeedbackWidget button styles,
+    causing only the first button to be visible.
+    """
+
+    def test_button_rule_is_scoped_to_dialog(self):
+        """Button CSS rules must be scoped (e.g., #dialog Button), not global.
+
+        An unscoped `Button { ... }` rule would override button styles
+        in every other widget (e.g., CriticFeedbackWidget).
+        """
+        tcss_content = EXIT_MODAL_TCSS_PATH.read_text()
+
+        # Find all Button selector lines (ignoring comments)
+        # Match lines like "Button {" but not "#dialog Button {" or ".foo Button {"
+        unscoped_button_rules = re.findall(
+            r"^\s*Button\s*\{", tcss_content, re.MULTILINE
+        )
+
+        assert not unscoped_button_rules, (
+            f"Found unscoped global 'Button' rule(s) in exit_modal.tcss. "
+            f"Button rules must be scoped to a parent (e.g., '#dialog Button') "
+            f"to avoid overriding button styles in other widgets. "
+            f"See: https://github.com/OpenHands/OpenHands-CLI/issues/641"
+        )
 
 
 class TestExitConfirmationModal:

--- a/tests/tui/modals/test_exit_modal.py
+++ b/tests/tui/modals/test_exit_modal.py
@@ -8,6 +8,7 @@ from textual.widgets import Button
 
 from openhands_cli.tui.modals.exit_modal import ExitConfirmationModal
 
+
 # Path to exit modal TCSS relative to the modal module
 EXIT_MODAL_TCSS_PATH = (
     Path(__file__).resolve().parents[3]
@@ -41,10 +42,10 @@ class TestExitModalCssScoping:
         )
 
         assert not unscoped_button_rules, (
-            f"Found unscoped global 'Button' rule(s) in exit_modal.tcss. "
-            f"Button rules must be scoped to a parent (e.g., '#dialog Button') "
-            f"to avoid overriding button styles in other widgets. "
-            f"See: https://github.com/OpenHands/OpenHands-CLI/issues/641"
+            "Found unscoped global 'Button' rule(s) in exit_modal.tcss. "
+            "Button rules must be scoped to a parent (e.g., '#dialog Button') "
+            "to avoid overriding button styles in other widgets. "
+            "See: https://github.com/OpenHands/OpenHands-CLI/issues/641"
         )
 
 

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -1199,8 +1199,6 @@ class TestRenderUserMessage:
 
     def test_render_user_message_creates_static_widget(self):
         """render_user_message should create a Static widget with user message."""
-        from unittest.mock import MagicMock
-
         app = MagicMock()
         container = MagicMock()
         visualizer = ConversationVisualizer(container, app)
@@ -1224,8 +1222,6 @@ class TestRenderUserMessage:
 
     def test_render_user_message_format(self):
         """render_user_message should prefix content with '> '."""
-        from unittest.mock import MagicMock
-
         app = MagicMock()
         container = MagicMock()
         visualizer = ConversationVisualizer(container, app)
@@ -1456,68 +1452,71 @@ class TestCriticFeedbackDismissalOnNewEvent:
     when subsequent events/actions appear in the conversation history.
     """
 
-    def test_on_event_dismisses_pending_feedback_widgets(self, mock_cli_settings):
-        """on_event should dismiss pending CriticFeedbackWidgets.
-
-        When a new event arrives, any existing CriticFeedbackWidget should be
-        removed because the agent has continued working and the feedback
-        opportunity has passed.
-        """
-        app: OpenHandsApp = cast(OpenHandsApp, App())
-        container = VerticalScroll()
-        visualizer = ConversationVisualizer(container, app)
-
-        # Mock _dismiss_pending_feedback_widgets to track calls
-        visualizer._dismiss_pending_feedback_widgets = MagicMock()  # type: ignore[method-assign]
-        # Mock _add_widget_to_ui since container isn't mounted in tests
-        visualizer._add_widget_to_ui = MagicMock()  # type: ignore[method-assign]
-        # Mock _run_on_main_thread to execute immediately (we're in a test)
-        visualizer._run_on_main_thread = lambda func, *args: func(*args)  # type: ignore[method-assign]
-
-        event = create_terminal_action_event("echo hello", "Say hello")
-
-        with mock_cli_settings(visualizer=visualizer):
-            visualizer.on_event(event)
-
-        # _dismiss_pending_feedback_widgets should have been called
-        visualizer._dismiss_pending_feedback_widgets.assert_called()
-
-    def test_on_event_dismisses_feedback_before_adding_new_widgets(
+    async def test_feedback_widget_removed_from_dom_on_new_event(
         self, mock_cli_settings
     ):
-        """Feedback widgets should be dismissed before new event widgets are added.
+        """CriticFeedbackWidget should be removed from the DOM when on_event fires.
 
-        This ensures the dismiss happens at the start of on_event, not after
-        a new critic result might be added.
+        Scenario:
+        1. A CriticFeedbackWidget is mounted in a VerticalScroll container
+        2. A new action event arrives via on_event()
+        3. The feedback widget should be removed from the container
+
+        This is an integration test using Textual's async test framework
+        to verify actual DOM state, not just method calls.
         """
-        app: OpenHandsApp = cast(OpenHandsApp, App())
-        container = VerticalScroll()
-        visualizer = ConversationVisualizer(container, app)
+        from textual.app import ComposeResult
 
-        call_order: list[str] = []
+        from openhands_cli.tui.utils.critic.feedback import CriticFeedbackWidget
 
-        original_dismiss = visualizer._dismiss_pending_feedback_widgets
+        # Create a mock CriticResult
+        mock_result = MagicMock()
+        mock_result.score = 0.65
+        mock_result.success = True
+        mock_result.metadata = {"event_ids": ["test-event-1"]}
 
-        def tracking_dismiss():
-            call_order.append("dismiss")
-            original_dismiss()
+        class FeedbackTestApp(App):
+            """Minimal app to test feedback widget dismissal."""
 
-        def tracking_add(widget):
-            call_order.append("add_widget")
-            # Don't actually mount (no running app in unit test)
+            def compose(self) -> ComposeResult:
+                yield VerticalScroll(id="scroll_view")
 
-        visualizer._dismiss_pending_feedback_widgets = tracking_dismiss  # type: ignore[method-assign]
-        visualizer._add_widget_to_ui = tracking_add  # type: ignore[method-assign]
-        # Execute functions immediately instead of scheduling on main thread
-        visualizer._run_on_main_thread = lambda func, *args: func(*args)  # type: ignore[method-assign]
+        app = FeedbackTestApp()
 
-        event = create_terminal_action_event("ls -la", "List files")
+        async with app.run_test() as pilot:
+            container = pilot.app.query_one("#scroll_view", VerticalScroll)
 
-        with mock_cli_settings(visualizer=visualizer):
-            visualizer.on_event(event)
+            # Mount a CriticFeedbackWidget (simulating what the visualizer does)
+            feedback_widget = CriticFeedbackWidget(
+                critic_result=mock_result,
+                conversation_id="test-conv-123",
+            )
+            await container.mount(feedback_widget)
+            await pilot.pause()
 
-        # Dismiss should happen before any widget is added
-        assert len(call_order) >= 1
-        assert call_order[0] == "dismiss", (
-            f"Expected dismiss to be called first, but call order was: {call_order}"
-        )
+            # Verify the feedback widget is in the DOM
+            feedback_widgets = container.query(CriticFeedbackWidget)
+            assert len(feedback_widgets) == 1, (
+                "CriticFeedbackWidget should be mounted in the container"
+            )
+
+            # Create a visualizer pointing at the same container
+            visualizer = ConversationVisualizer(container, pilot.app)  # type: ignore[arg-type]
+            # Run on main thread directly (we're already in the event loop)
+            visualizer._run_on_main_thread = lambda func, *args: func(*args)  # type: ignore[method-assign]
+            # Prevent actual widget mounting in on_event
+            visualizer._add_widget_to_ui = MagicMock()  # type: ignore[method-assign]
+
+            # Fire a new event — this should dismiss the feedback widget
+            event = create_terminal_action_event("echo hello", "Say hello")
+            with mock_cli_settings(visualizer=visualizer):
+                visualizer.on_event(event)
+
+            await pilot.pause()
+
+            # The feedback widget should now be removed from the DOM
+            remaining = container.query(CriticFeedbackWidget)
+            assert len(remaining) == 0, (
+                "CriticFeedbackWidget should be removed after a new event arrives, "
+                f"but {len(remaining)} widget(s) still present"
+            )

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -1,7 +1,7 @@
 """Tests for ConversationVisualizer and Chinese character markup handling."""
 
 from typing import TYPE_CHECKING, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from rich.errors import MarkupError
@@ -1441,3 +1441,85 @@ class TestDefaultAgentPrefixBehavior:
         assert "(Code Reviewer Agent)" in title
         # Should contain the command
         assert "git diff" in title
+
+
+# ============================================================================
+# Tests for critic feedback widget dismissal on new events (GitHub issue #641)
+# ============================================================================
+
+
+class TestCriticFeedbackDismissalOnNewEvent:
+    """Tests that CriticFeedbackWidget is dismissed when new events arrive.
+
+    Relates to: https://github.com/OpenHands/OpenHands-CLI/issues/641
+    The critic feedback buttons ("[1] Accurate", etc.) should not remain visible
+    when subsequent events/actions appear in the conversation history.
+    """
+
+    def test_on_event_dismisses_pending_feedback_widgets(self, mock_cli_settings):
+        """on_event should dismiss pending CriticFeedbackWidgets.
+
+        When a new event arrives, any existing CriticFeedbackWidget should be
+        removed because the agent has continued working and the feedback
+        opportunity has passed.
+        """
+        app: OpenHandsApp = cast(OpenHandsApp, App())
+        container = VerticalScroll()
+        visualizer = ConversationVisualizer(container, app)
+
+        # Mock _dismiss_pending_feedback_widgets to track calls
+        visualizer._dismiss_pending_feedback_widgets = MagicMock()  # type: ignore[method-assign]
+        # Mock _add_widget_to_ui since container isn't mounted in tests
+        visualizer._add_widget_to_ui = MagicMock()  # type: ignore[method-assign]
+        # Mock _run_on_main_thread to execute immediately (we're in a test)
+        visualizer._run_on_main_thread = lambda func, *args: func(*args)  # type: ignore[method-assign]
+
+        event = create_terminal_action_event("echo hello", "Say hello")
+
+        with mock_cli_settings(visualizer=visualizer):
+            visualizer.on_event(event)
+
+        # _dismiss_pending_feedback_widgets should have been called
+        visualizer._dismiss_pending_feedback_widgets.assert_called()
+
+    def test_on_event_dismisses_feedback_before_adding_new_widgets(
+        self, mock_cli_settings
+    ):
+        """Feedback widgets should be dismissed before new event widgets are added.
+
+        This ensures the dismiss happens at the start of on_event, not after
+        a new critic result might be added.
+        """
+        app: OpenHandsApp = cast(OpenHandsApp, App())
+        container = VerticalScroll()
+        visualizer = ConversationVisualizer(container, app)
+
+        call_order: list[str] = []
+
+        original_dismiss = visualizer._dismiss_pending_feedback_widgets
+        original_add = visualizer._add_widget_to_ui
+
+        def tracking_dismiss():
+            call_order.append("dismiss")
+            original_dismiss()
+
+        def tracking_add(widget):
+            call_order.append("add_widget")
+            # Don't actually mount (no running app in unit test)
+
+        visualizer._dismiss_pending_feedback_widgets = tracking_dismiss  # type: ignore[method-assign]
+        visualizer._add_widget_to_ui = tracking_add  # type: ignore[method-assign]
+        # Execute functions immediately instead of scheduling on main thread
+        visualizer._run_on_main_thread = lambda func, *args: func(*args)  # type: ignore[method-assign]
+
+        event = create_terminal_action_event("ls -la", "List files")
+
+        with mock_cli_settings(visualizer=visualizer):
+            visualizer.on_event(event)
+
+        # Dismiss should happen before any widget is added
+        assert len(call_order) >= 1
+        assert call_order[0] == "dismiss", (
+            f"Expected dismiss to be called first, but call order was: {call_order}"
+        )
+

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -1497,7 +1497,6 @@ class TestCriticFeedbackDismissalOnNewEvent:
         call_order: list[str] = []
 
         original_dismiss = visualizer._dismiss_pending_feedback_widgets
-        original_add = visualizer._add_widget_to_ui
 
         def tracking_dismiss():
             call_order.append("dismiss")
@@ -1522,4 +1521,3 @@ class TestCriticFeedbackDismissalOnNewEvent:
         assert call_order[0] == "dismiss", (
             f"Expected dismiss to be called first, but call order was: {call_order}"
         )
-


### PR DESCRIPTION
## Summary

Fixes #641 — Two issues with the critic feedback widget:

### Issue 1: Feedback buttons not dismissed when agent continues
The critic feedback buttons (`[1] Accurate`, `[2] Too high`, etc.) persisted in the conversation history even after subsequent events/actions appeared.

**Root cause:** `_dismiss_pending_feedback_widgets()` was only called on user/refinement messages, not when new events arrived via `on_event()`.

**Fix:** Added `self._run_on_main_thread(self._dismiss_pending_feedback_widgets)` at the start of `on_event()` in `richlog_visualizer.py`.

### Issue 2: Only "[1] Accurate" button visible (others hidden)
Only the first button was visible because the other 4 were pushed off-screen.

**Root cause:** An unscoped `Button { width: 100%; height: 3; }` rule in `exit_modal.tcss` was overriding the feedback widget's `CriticFeedbackWidget Button { width: 12; }` (defined in `DEFAULT_CSS`, which has lower CSS priority). Each button expanded to full width, so only the first fit.

**Fix:** Scoped the rule to `#dialog Button` so it only applies to the exit/switch-conversation modal dialogs.

## Changes

- **`openhands_cli/tui/widgets/richlog_visualizer.py`**: Dismiss pending feedback widgets at the start of `on_event()`
- **`openhands_cli/tui/modals/exit_modal.tcss`**: `Button { ... }` → `#dialog Button { ... }`
- **`tests/tui/widgets/test_richlog_visualizer.py`**: 2 tests for feedback dismissal on new events
- **`tests/tui/modals/test_exit_modal.py`**: Regression test validating no unscoped `Button` rules in exit_modal.tcss
- **`tests/snapshots/test_critic_feedback_snapshots.py`**: Snapshot test for feedback widget inside VerticalScroll (real app context)

## Verification

```
make lint           # ✅ passed
make test           # ✅ 1280 passed
make test-snapshots # ✅ 19 passed (including exit modal snapshot — no visual regression)
```

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@openhands/fix-critic-button-641
```