### PR TITLE
feat(cloud): Migrate openhands cloud to V1 API endpoints

### DIFF
--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -77,15 +77,16 @@ class OpenHandsApiClient(BaseHttpClient):
     async def create_conversation(
         self, json_data: dict[str, Any] | None = None
     ) -> httpx.Response:
-        return await self.post("/api/conversations", self._headers, json_data)
+        return await self.post("/api/v1/app-conversations", self._headers, json_data)
 
     async def get_conversation_info(
-        self, conversation_id: str
+        self, conversation_id: str, endpoint: str = ""
     ) -> dict[str, Any] | None:
         """Get conversation information including sandbox_id.
 
         Args:
             conversation_id: The conversation ID to look up
+            endpoint: Optional sub-endpoint (e.g. "start-tasks")
 
         Returns:
             Conversation info dict if found, None if not found
@@ -94,7 +95,7 @@ class OpenHandsApiClient(BaseHttpClient):
             UnauthenticatedError: If the user is not authenticated (401 response)
             ApiClientError: For other API errors
         """
-        path = f"/api/v1/app-conversations?ids={conversation_id}"
+        path = self._v1_conversations_path(conversation_id, endpoint)
         try:
             response = await self.get(path, headers=self._headers)
         except AuthHttpError as e:
@@ -105,9 +106,24 @@ class OpenHandsApiClient(BaseHttpClient):
             raise ApiClientError(f"Request to {path!r} failed: {e}") from e
 
         data: list[dict[str, Any]] = response.json()
-        if len(data) > 0:
+        if data and data[0]:
             return data[0]
         return None
+
+    @staticmethod
+    def _v1_conversations_path(id: str, endpoint: str = "") -> str:
+        """Build a V1 app-conversations endpoint path."""
+        base = "/api/v1/app-conversations"
+        return f"{base}/{endpoint}?ids={id}" if endpoint else f"{base}?ids={id}"
+
+    async def get_start_task_status(self, task_id: str) -> dict[str, Any] | None:
+        """Poll the status of a conversation start-task.
+
+        After ``create_conversation`` the V1 API returns a start-task whose
+        ``app_conversation_id`` is initially None.  Call this method to check
+        whether the conversation has been provisioned.
+        """
+        return await self.get_conversation_info(task_id, endpoint="start-tasks")
 
 
 def _print_settings_summary(settings: dict[str, Any]) -> None:

--- a/openhands_cli/cloud/conversation.py
+++ b/openhands_cli/cloud/conversation.py
@@ -12,6 +12,7 @@ Future maintainers: Please move methods from here into the `CloudStore` class
 implementation and deprecate this module.
 """
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -30,7 +31,12 @@ class CloudConversationError(Exception):
 
 
 async def create_cloud_conversation(
-    server_url: str, api_key: str, initial_user_msg: str
+    server_url: str,
+    api_key: str,
+    initial_user_msg: str,
+    *,
+    poll_interval: float = 2.0,
+    poll_max_attempts: int = 15,
 ) -> dict[str, Any]:
     """Create a new conversation in OpenHands Cloud.
 
@@ -38,6 +44,8 @@ async def create_cloud_conversation(
         server_url: OpenHands server URL
         api_key: Valid API key for authentication
         initial_user_msg: Initial message for the conversation
+        poll_interval: Seconds between start-task polling attempts
+        poll_max_attempts: Maximum number of polling attempts
 
     Returns:
         Conversation data from the server
@@ -58,9 +66,13 @@ async def create_cloud_conversation(
             style=OPENHANDS_THEME.secondary,
         )
 
-    payload: dict[str, Any] = {"initial_user_msg": initial_user_msg}
+    payload: dict[str, Any] = {
+        "initial_message": {
+            "content": [{"type": "text", "text": initial_user_msg}],
+        }
+    }
     if repo:
-        payload["repository"] = repo
+        payload["selected_repository"] = repo
     if branch:
         payload["selected_branch"] = branch
 
@@ -77,7 +89,35 @@ async def create_cloud_conversation(
         )
         raise CloudConversationError(f"Failed to create conversation: {e}") from e
 
-    conversation_id = conversation.get("conversation_id")
+    task_id = conversation.get("id")
+    app_conversation_id = conversation.get("app_conversation_id")
+
+    # V1 returns a start-task; poll until app_conversation_id is available
+    if not app_conversation_id and task_id:
+        console_print(
+            "Waiting for conversation to start...", style=OPENHANDS_THEME.secondary
+        )
+        for _ in range(poll_max_attempts):
+            await asyncio.sleep(poll_interval)
+            task_info = await client.get_start_task_status(task_id)
+            if task_info:
+                status = task_info.get("status")
+                app_conversation_id = task_info.get("app_conversation_id")
+                if app_conversation_id:
+                    break
+                if status == "ERROR":
+                    detail = task_info.get("detail", "Unknown error")
+                    raise CloudConversationError(
+                        f"Conversation failed to start: {detail}"
+                    )
+
+    conversation_id = app_conversation_id or task_id
+    if not app_conversation_id:
+        console_print(
+            "⚠️ Conversation is still initializing. "
+            "The link below may take a moment to become active.",
+            style=OPENHANDS_THEME.warning,
+        )
     console_print(
         f"Conversation ID: [{accent}]{conversation_id}[/{accent}]",
         style=OPENHANDS_THEME.secondary,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
   "textual-dev>=1.8.0",
   "pytest-httpserver>=1.1.3",
   "watchfiles>=1.1.1",
+  "respx>=0.22.0",
 ]
 
 [tool.hatch.metadata]

--- a/tests/auth/test_api_client.py
+++ b/tests/auth/test_api_client.py
@@ -143,6 +143,18 @@ class TestOpenHandsApiClient:
             ):
                 await client._get_json("/test")
 
+    def test_v1_conversations_path_without_endpoint(self):
+        assert (
+            OpenHandsApiClient._v1_conversations_path("abc")
+            == "/api/v1/app-conversations?ids=abc"
+        )
+
+    def test_v1_conversations_path_with_endpoint(self):
+        assert (
+            OpenHandsApiClient._v1_conversations_path("abc", "start-tasks")
+            == "/api/v1/app-conversations/start-tasks?ids=abc"
+        )
+
 
 class TestHelperFunctions:
     """Test cases for helper functions in api_client module."""

--- a/tests/cloud/mock_responses/start_task_error.json
+++ b/tests/cloud/mock_responses/start_task_error.json
@@ -1,0 +1,11 @@
+{
+  "id": "a1b2c3d4e5f6789012345678901234ab",
+  "created_by_user_id": "user123",
+  "status": "ERROR",
+  "detail": "sandbox provisioning failed",
+  "app_conversation_id": null,
+  "sandbox_id": null,
+  "agent_server_url": null,
+  "created_at": "2026-01-01T00:00:00.000000Z",
+  "updated_at": "2026-01-01T00:00:01.000000Z"
+}

--- a/tests/cloud/mock_responses/start_task_pending.json
+++ b/tests/cloud/mock_responses/start_task_pending.json
@@ -1,0 +1,12 @@
+{
+  "id": "a1b2c3d4e5f6789012345678901234ab",
+  "created_by_user_id": "user123",
+  "status": "WORKING",
+  "detail": null,
+  "app_conversation_id": null,
+  "sandbox_id": null,
+  "agent_server_url": null,
+  "request": {},
+  "created_at": "2026-01-01T00:00:00.000000Z",
+  "updated_at": "2026-01-01T00:00:00.000000Z"
+}

--- a/tests/cloud/mock_responses/start_task_ready.json
+++ b/tests/cloud/mock_responses/start_task_ready.json
@@ -1,0 +1,11 @@
+{
+  "id": "a1b2c3d4e5f6789012345678901234ab",
+  "created_by_user_id": "user123",
+  "status": "READY",
+  "detail": null,
+  "app_conversation_id": "conv-001",
+  "sandbox_id": "sandbox-abc",
+  "agent_server_url": null,
+  "created_at": "2026-01-01T00:00:00.000000Z",
+  "updated_at": "2026-01-01T00:00:01.000000Z"
+}

--- a/tests/cloud/test_api_client_transport.py
+++ b/tests/cloud/test_api_client_transport.py
@@ -1,0 +1,164 @@
+"""Transport-level tests for OpenHandsApiClient using respx.
+
+These tests let the real client code execute (path building, headers,
+response parsing) and only mock HTTP at the transport layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from openhands_cli.auth.api_client import (
+    OpenHandsApiClient,
+    UnauthenticatedError,
+)
+
+
+MOCK_RESPONSES = Path(__file__).parent / "mock_responses"
+SERVER = "https://app.test.dev"
+API_KEY = "test-key"
+TASK_ID = "a1b2c3d4e5f6789012345678901234ab"
+
+
+def _load(name: str) -> dict:
+    return json.loads((MOCK_RESPONSES / name).read_text())
+
+
+@pytest.fixture
+def client() -> OpenHandsApiClient:
+    return OpenHandsApiClient(SERVER, API_KEY)
+
+
+# ----------------------------
+# create_conversation
+# ----------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_create_conversation_sends_correct_request(client):
+    pending = _load("start_task_pending.json")
+    route = respx.post(f"{SERVER}/api/v1/app-conversations").mock(
+        return_value=httpx.Response(200, json=pending)
+    )
+
+    payload = {
+        "initial_message": {"content": [{"type": "text", "text": "hello"}]},
+        "selected_repository": "owner/repo",
+    }
+    resp = await client.create_conversation(json_data=payload)
+
+    assert route.called
+    req = route.calls.last.request
+    assert req.headers["authorization"] == f"Bearer {API_KEY}"
+    assert json.loads(req.content) == payload
+    assert resp.json()["id"] == TASK_ID
+    assert resp.json()["status"] == "WORKING"
+
+
+# ----------------------------
+# get_start_task_status
+# ----------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_start_task_status_ready(client):
+    ready = _load("start_task_ready.json")
+    route = respx.get(
+        f"{SERVER}/api/v1/app-conversations/start-tasks",
+        params={"ids": TASK_ID},
+    ).mock(return_value=httpx.Response(200, json=[ready]))
+
+    result = await client.get_start_task_status(TASK_ID)
+
+    assert route.called
+    assert result["status"] == "READY"
+    assert result["app_conversation_id"] == "conv-001"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_start_task_status_error(client):
+    error = _load("start_task_error.json")
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations/start-tasks",
+        params={"ids": TASK_ID},
+    ).mock(return_value=httpx.Response(200, json=[error]))
+
+    result = await client.get_start_task_status(TASK_ID)
+
+    assert result["status"] == "ERROR"
+    assert result["detail"] == "sandbox provisioning failed"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_start_task_status_not_found(client):
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations/start-tasks",
+        params={"ids": TASK_ID},
+    ).mock(return_value=httpx.Response(200, json=[None]))
+
+    result = await client.get_start_task_status(TASK_ID)
+    assert result is None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_start_task_status_401(client):
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations/start-tasks",
+        params={"ids": TASK_ID},
+    ).mock(return_value=httpx.Response(401))
+
+    with pytest.raises(UnauthenticatedError):
+        await client.get_start_task_status(TASK_ID)
+
+
+# ----------------------------
+# get_conversation_info
+# ----------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_conversation_info_found(client):
+    conv = {"id": "conv-001", "sandbox_id": "sb-1", "execution_status": "finished"}
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations",
+        params={"ids": "conv-001"},
+    ).mock(return_value=httpx.Response(200, json=[conv]))
+
+    result = await client.get_conversation_info("conv-001")
+
+    assert result["sandbox_id"] == "sb-1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_conversation_info_not_found(client):
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations",
+        params={"ids": "missing"},
+    ).mock(return_value=httpx.Response(200, json=[None]))
+
+    result = await client.get_conversation_info("missing")
+    assert result is None
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_conversation_info_401(client):
+    respx.get(
+        f"{SERVER}/api/v1/app-conversations",
+        params={"ids": "conv-001"},
+    ).mock(return_value=httpx.Response(401))
+
+    with pytest.raises(UnauthenticatedError):
+        await client.get_conversation_info("conv-001")

--- a/tests/cloud/test_conversation.py
+++ b/tests/cloud/test_conversation.py
@@ -215,13 +215,22 @@ def test_extract_repository_from_cwd_branch_missing_is_ok():
 @pytest.mark.parametrize(
     "repo_branch,expected_payload",
     [
-        ((None, None), {"initial_user_msg": "hi"}),
-        (("owner/repo", None), {"initial_user_msg": "hi", "repository": "owner/repo"}),
+        (
+            (None, None),
+            {"initial_message": {"content": [{"type": "text", "text": "hi"}]}},
+        ),
+        (
+            ("owner/repo", None),
+            {
+                "initial_message": {"content": [{"type": "text", "text": "hi"}]},
+                "selected_repository": "owner/repo",
+            },
+        ),
         (
             ("owner/repo", "main"),
             {
-                "initial_user_msg": "hi",
-                "repository": "owner/repo",
+                "initial_message": {"content": [{"type": "text", "text": "hi"}]},
+                "selected_repository": "owner/repo",
                 "selected_branch": "main",
             },
         ),
@@ -239,12 +248,12 @@ async def test_create_cloud_conversation_payload_includes_repo_and_branch(
     ):
         client = Mock()
         resp = Mock()
-        resp.json.return_value = {"conversation_id": "c1"}
+        resp.json.return_value = {"id": "c1", "app_conversation_id": "ac1"}
         client.create_conversation = AsyncMock(return_value=resp)
         mock_client_cls.return_value = client
 
         result = await create_cloud_conversation("https://server", "key", "hi")
-        assert result["conversation_id"] == "c1"
+        assert result["id"] == "c1"
         client.create_conversation.assert_called_once_with(json_data=expected_payload)
 
 
@@ -265,3 +274,165 @@ async def test_create_cloud_conversation_propagates_api_error_as_cloud_error():
             CloudConversationError, match=r"Failed to create conversation: boom"
         ):
             await create_cloud_conversation("https://server", "key", "hi")
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_polls_for_app_conversation_id():
+    """When app_conversation_id is None initially, poll start-tasks until ready."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {"id": "t1", "app_conversation_id": None}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock(
+            side_effect=[
+                {"id": "t1", "status": "WORKING", "app_conversation_id": None},
+                {"id": "t1", "status": "READY", "app_conversation_id": "ac1"},
+            ]
+        )
+        mock_client_cls.return_value = client
+
+        result = await create_cloud_conversation(
+            "https://server", "key", "hi", poll_interval=0
+        )
+        assert result["id"] == "t1"
+        assert client.get_start_task_status.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_raises_on_start_task_error():
+    """When start-task status is ERROR, raise CloudConversationError."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {"id": "t1", "app_conversation_id": None}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock(
+            return_value={
+                "id": "t1",
+                "status": "ERROR",
+                "detail": "sandbox failed",
+                "app_conversation_id": None,
+            }
+        )
+        mock_client_cls.return_value = client
+
+        with pytest.raises(CloudConversationError, match="sandbox failed"):
+            await create_cloud_conversation(
+                "https://server", "key", "hi", poll_interval=0
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_polls_timeout_falls_back_to_task_id():
+    """When polling exhausts all attempts, fall back to task_id for the URL."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {"id": "t1", "app_conversation_id": None}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock(
+            return_value={"id": "t1", "status": "WORKING", "app_conversation_id": None}
+        )
+        mock_client_cls.return_value = client
+
+        result = await create_cloud_conversation(
+            "https://server", "key", "hi", poll_interval=0, poll_max_attempts=2
+        )
+        assert result["id"] == "t1"
+        assert client.get_start_task_status.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_timeout_shows_warning(capsys):
+    """When polling times out, print a warning about the link."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {"id": "t1", "app_conversation_id": None}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock(
+            return_value={"id": "t1", "status": "WORKING", "app_conversation_id": None}
+        )
+        mock_client_cls.return_value = client
+
+        await create_cloud_conversation(
+            "https://server", "key", "hi", poll_interval=0, poll_max_attempts=1
+        )
+        output = capsys.readouterr().out
+        assert "still initializing" in output
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_poll_handles_none_task_info():
+    """When get_start_task_status returns None, keep polling."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {"id": "t1", "app_conversation_id": None}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock(
+            side_effect=[
+                None,
+                {"id": "t1", "status": "READY", "app_conversation_id": "ac1"},
+            ]
+        )
+        mock_client_cls.return_value = client
+
+        result = await create_cloud_conversation(
+            "https://server", "key", "hi", poll_interval=0
+        )
+        assert result["id"] == "t1"
+        assert client.get_start_task_status.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_cloud_conversation_skips_polling_when_no_task_id():
+    """When response has no id at all, skip polling entirely."""
+    with (
+        patch(
+            "openhands_cli.cloud.conversation.extract_repository_from_cwd",
+            return_value=(None, None),
+        ),
+        patch("openhands_cli.cloud.conversation.OpenHandsApiClient") as mock_client_cls,
+    ):
+        client = Mock()
+        resp = Mock()
+        resp.json.return_value = {}
+        client.create_conversation = AsyncMock(return_value=resp)
+        client.get_start_task_status = AsyncMock()
+        mock_client_cls.return_value = client
+
+        result = await create_cloud_conversation("https://server", "key", "hi")
+        assert result == {}
+        client.get_start_task_status.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,6 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
-
-[options]
-exclude-newer = "2026-03-26T17:28:23.771594048Z"
-exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-openhands-tools = false
-openhands-sdk = false
 
 [[package]]
 name = "agent-client-protocol"
@@ -689,7 +681,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -714,9 +706,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -1485,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1503,9 +1495,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -1697,6 +1689,7 @@ dev = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-textual-snapshot" },
     { name = "pytest-xdist" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "textual-dev" },
     { name = "watchfiles" },
@@ -1736,6 +1729,7 @@ dev = [
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "pytest-textual-snapshot", specifier = ">=1.1.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.12.10" },
     { name = "textual-dev", specifier = ">=1.8.0" },
     { name = "watchfiles", specifier = ">=1.1.1" },
@@ -5043,6 +5037,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary of PR

Migrates openhands cloud from the deprecated V0 API (/api/conversations) to the V1 API (/api/v1/app-conversations), per the [Cloud API migration guide](https://docs.all-hands.dev/usage/cloud/cloud-api#migrating-
from-v0-to-v1-api).

API changes:
- Endpoint: /api/conversations → /api/v1/app-conversations
- Payload: initial_user_msg (string) → initial_message.content (array of content objects)
- Field: repository → selected_repository
- Response: V1 returns an async start-task; polls /api/v1/app-conversations/start-tasks?ids= for app_conversation_id

Code changes:
- openhands_cli/auth/api_client.py: Updated create_conversation endpoint, added get_start_task_status method, extracted _v1_conversations_path helper to deduplicate path building with get_conversation_info
- openhands_cli/cloud/conversation.py: Updated payload format, added polling loop for app_conversation_id with error handling for start-task ERROR status
- tests/cloud/test_conversation.py: Updated existing tests for V1 payload, added 5 new tests covering polling success, timeout, error, null response, and missing task ID

## Demo Screenshots/Videos




Manual test output:


```
▶ uv run openhands cloud -t "here is my prompt"
zsh: correct 'openhands' to '.openhands' [nyae]? n
Detected repository: sjathin/OpenHands-CLI
Detected branch: open-hands-cli-629
Creating cloud conversation...
Waiting for conversation to start...
Conversation ID: a824ad8bc0e64d54b8084f731095e824
View in browser: https://app.all-hands.dev/conversations/a824ad8bc0e64d54b8084f731095e824
Cloud conversation created successfully! 🚀
```

https://app.all-hands.dev/conversations/a824ad8bc0e64d54b8084f731095e824

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #629 

## Release Notes

- [x] Include this change in the Release Notes.

openhands cloud now uses the V1 API for creating conversations, with structured message format and async start-task polling. The deprecated V0 endpoint (/api/conversations) is no longer used.