### PR TITLE
ci: retire Blacksmith from all GitHub Actions workflows

### DIFF
--- a/.github/workflows/bump-agent-sdk-version.yml
+++ b/.github/workflows/bump-agent-sdk-version.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     bump-version:
         name: Bump agent-sdk version to ${{ inputs.version }}
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
     bump-version:
         name: Bump version and create draft PR
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/check-package-versions.yml
+++ b/.github/workflows/check-package-versions.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     check-package-versions:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/cli-build-binary-and-optionally-release.yml
+++ b/.github/workflows/cli-build-binary-and-optionally-release.yml
@@ -93,7 +93,7 @@ jobs:
 
     create-github-release:
         name: Create GitHub Release
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         needs: build-binary
         if: startsWith(github.ref, 'refs/tags/')
         steps:

--- a/.github/workflows/good-first-issue-labeler.yml
+++ b/.github/workflows/good-first-issue-labeler.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
     label-good-first-issues:
         if: github.repository == 'OpenHands/OpenHands-CLI'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     pre-commit:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout code

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
     release-cli:
         name: Publish CLI to PyPI
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         permissions:
             id-token: write
     # Run when manually dispatched for "cli" OR for any tag pushes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     test-unit:
         name: Run unit tests (pytest)
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository
@@ -88,7 +88,7 @@ jobs:
 
     test-snapshots:
         name: Run snapshot tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository
@@ -124,7 +124,7 @@ jobs:
 
     coverage-report:
         name: Generate coverage report
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         needs: [test-unit]
         if: always() && github.event_name == 'pull_request'
 

--- a/.github/workflows/type-checking-report.yml
+++ b/.github/workflows/type-checking-report.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
     code-quality-report:
         name: Generate Code Quality Report
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         if: github.repository == 'OpenHands/OpenHands-CLI'
         outputs:
             issue_number: ${{ steps.create_issue.outputs.issue_number }}
@@ -161,7 +161,7 @@ jobs:
 
     auto-fix-low-hanging:
         name: Auto-fix Low-Hanging Improvements
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         needs: code-quality-report
         if: |
             needs.code-quality-report.outputs.report_generated == 'true' &&


### PR DESCRIPTION
Human: For cost reasons we're retiring Blacksmith, similar to https://github.com/OpenHands/OpenHands/pull/13795.

## Changes

Removes all Blacksmith CI runner references from GitHub Actions workflows, replacing them with standard GitHub-hosted equivalents.

### Runner replacements
| Blacksmith | GitHub |
|---|---|
| `blacksmith-2vcpu-ubuntu-2404` | `ubuntu-24.04` |

### Affected workflows (9 files)
- `bump-agent-sdk-version.yml`
- `bump-version.yml`
- `check-package-versions.yml`
- `cli-build-binary-and-optionally-release.yml`
- `good-first-issue-labeler.yml`
- `lint.yml`
- `pypi-release.yml`
- `tests.yml`
- `type-checking-report.yml`

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@raymyers can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/c9a23e24-2cd0-4971-bc94-fc0c418c0436)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@remove-blacksmith
```