### PR TITLE
feat(delegate): register built-in sub-agents so delegation works out of the box

### DIFF
--- a/openhands_cli/setup.py
+++ b/openhands_cli/setup.py
@@ -25,6 +25,52 @@ class MissingAgentSpec(Exception):
     pass
 
 
+_builtin_agents_registered = False
+
+
+def ensure_builtin_agents_registered() -> None:
+    """Register SDK built-in sub-agent types so the delegate tool can spawn them.
+
+    Registers agents like "default", "bash", and "explore" that are shipped with
+    the SDK.  Safe to call multiple times — subsequent calls are no-ops.
+
+    In SDK v1.16.x, ``register_builtins_agents(cli_mode=True)`` registers the
+    CLI default agent under the name ``"default cli mode"`` while
+    ``DelegateExecutor`` resolves unnamed agent types to ``"default"``.  We
+    bridge this gap by also registering the CLI factory under the ``"default"``
+    name.  This workaround can be removed once the SDK ships the
+    ``enable_browser`` parameter (already on ``main``).
+    """
+    global _builtin_agents_registered
+    if _builtin_agents_registered:
+        return
+
+    from openhands.sdk.subagent.registry import (
+        get_agent_factory,
+        register_agent_if_absent,
+    )
+    from openhands.tools import register_builtins_agents
+
+    register_builtins_agents(cli_mode=True)
+
+    # Workaround: SDK v1.16.x registers the CLI default as "default cli mode"
+    # but DelegateExecutor._resolve_agent_type() defaults to "default".
+    try:
+        get_agent_factory("default")
+    except ValueError:
+        try:
+            cli_factory = get_agent_factory("default cli mode")
+            register_agent_if_absent(
+                name="default",
+                factory_func=cli_factory.factory_func,
+                description=cli_factory.definition,
+            )
+        except ValueError:
+            pass  # no CLI default either — nothing to alias
+
+    _builtin_agents_registered = True
+
+
 def load_agent_specs(
     conversation_id: str | None = None,
     mcp_servers: dict[str, dict[str, Any]] | None = None,
@@ -121,6 +167,8 @@ def setup_conversation(
     if console is None:
         console = Console()
     console.print("Initializing agent...", style="white")
+
+    ensure_builtin_agents_registered()
 
     agent = load_agent_specs(
         str(conversation_id),

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,73 @@
+"""Tests for setup module — builtin agent registration."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from openhands.sdk.subagent.registry import (
+    _agent_factories,
+    _reset_registry_for_tests,
+    get_agent_factory,
+)
+from openhands_cli.setup import ensure_builtin_agents_registered
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Reset the global agent registry before and after every test."""
+    _reset_registry_for_tests()
+    yield
+    _reset_registry_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _reset_registration_flag() -> None:
+    """Reset the module-level guard so each test starts fresh."""
+    import openhands_cli.setup as _mod
+
+    _mod._builtin_agents_registered = False
+
+
+def test_ensure_builtin_agents_registered_populates_registry() -> None:
+    """Calling ensure_builtin_agents_registered should populate the registry."""
+    assert len(_agent_factories) == 0
+    ensure_builtin_agents_registered()
+    assert len(_agent_factories) > 0
+
+
+def test_default_agent_is_registered() -> None:
+    """The 'default' agent type must be resolvable after registration."""
+    ensure_builtin_agents_registered()
+    factory = get_agent_factory("default")
+    assert factory is not None
+
+
+def test_builtin_agent_names() -> None:
+    """Expected built-in agent names should all be present."""
+    ensure_builtin_agents_registered()
+    names = set(_agent_factories.keys())
+    assert "default" in names
+    assert "bash" in names or "bash-runner" in names
+    assert "explore" in names or "code-explorer" in names
+
+
+def test_idempotent() -> None:
+    """Calling ensure_builtin_agents_registered twice should not raise."""
+    ensure_builtin_agents_registered()
+    count_after_first = len(_agent_factories)
+    ensure_builtin_agents_registered()
+    assert len(_agent_factories) == count_after_first
+
+
+def test_default_agent_has_expected_tools() -> None:
+    """The default agent should have terminal, file_editor, task_tracker."""
+    from pydantic import SecretStr
+
+    from openhands.sdk import LLM
+
+    ensure_builtin_agents_registered()
+    factory = get_agent_factory("default")
+    llm = LLM(model="gpt-4o", api_key=SecretStr("test-key"), usage_id="test")
+    agent = factory.factory_func(llm)
+    tool_names = {t.name for t in agent.tools}
+    assert tool_names == {"terminal", "file_editor", "task_tracker"}


### PR DESCRIPTION
## Problem

The CLI includes `DelegateTool` in its default toolset (`get_default_cli_tools()`) but never calls `register_builtins_agents()`, leaving the SDK's agent registry empty. When the LLM tries to spawn sub-agents via the delegate tool, `DelegateExecutor._resolve_agent_type()` defaults to `"default"`, but `get_agent_factory("default")` fails:

```
failed to spawn agents: Unknown agent 'default'. Available types:
none registered. Use register_agent() to add custom agent types.
```

## Root Cause

The SDK ships built-in sub-agent definitions (`default`, `bash`, `explore`) and provides `register_builtins_agents()` to register them — but it's the caller's responsibility to invoke it. The CLI never did.

Additionally, SDK v1.16.x has a naming mismatch: `register_builtins_agents(cli_mode=True)` registers the CLI default agent as `"default cli mode"`, while `DelegateExecutor` looks for `"default"`. This is already fixed on agent-sdk `main` (where the naming was reworked to `"general-purpose"` with deprecation aliases).

## Changes

- **`openhands_cli/setup.py`**: Add `ensure_builtin_agents_registered()` that:
  1. Calls `register_builtins_agents(cli_mode=True)` to register `"default cli mode"`, `"bash"`, `"explore"`
  2. Works around the v1.16.x naming mismatch by aliasing `"default cli mode"` → `"default"`
  3. Is idempotent (safe to call multiple times)
- Call it from `setup_conversation()` before creating conversations
- **`tests/test_setup.py`**: Tests verifying the registry is populated, `"default"` resolves correctly, expected tools are present, and the function is idempotent

The workaround for the naming mismatch can be removed once the SDK is upgraded to a version with the `enable_browser` parameter (already on agent-sdk `main`).

## Verification

```bash
make lint    # ✅ passed
make test    # ✅ 1298 passed
```

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/902ae801-a8cf-473c-9ec8-8a0e482549a8)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/register-builtin-subagents
```