### PR TITLE
makefile: avoid local .openhands writes during make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,17 +70,17 @@ install-dev: check-uv-version
 
 test: check-uv-version
 	@$(ECHO) "$(YELLOW)Run tests...$(RESET)"
-	uv run pytest --ignore=tests/snapshots
+	uv run env HOME="$$(mktemp -d)" pytest --ignore=tests/snapshots
 	@$(ECHO) "$(GREEN)Tests completed.$(RESET)"
 
 test-snapshots: check-uv-version
 	@$(ECHO) "$(YELLOW)Run snapshots tests...$(RESET)"
-	uv run pytest tests/snapshots -v
+	uv run env HOME="$$(mktemp -d)" pytest tests/snapshots -v
 	@$(ECHO) "$(GREEN)Snapshots tests completed.$(RESET)"
 
 test-binary: check-uv-version
 	@$(ECHO) "$(YELLOW)Run end-to-end tests...$(RESET)"
-	uv run pytest tui_e2e
+	uv run env HOME="$$(mktemp -d)" pytest tui_e2e
 	@$(ECHO) "$(GREEN)End-to-end tests completed.$(RESET)"
 
 test-all: test test-snapshots


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [X] A human has tested these changes.

---

## Why

Running make test locally can write into the local `~/.openhands` directory.

## Summary

- run `make test` with a temporary `HOME` to avoid local `~/.openhands` writes

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

Run `make test` and verify it does not create or write to the local `~/.openhands` directory.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->