### PR TITLE
tests: prevent browser opening in device flow test

### DIFF
--- a/tests/auth/test_device_flow.py
+++ b/tests/auth/test_device_flow.py
@@ -426,8 +426,15 @@ class TestDeviceFlowClient:
                 mock_poll.side_effect = DeviceFlowError("Polling failed")
 
                 with patch("openhands_cli.auth.device_flow.console_print"):
-                    with pytest.raises(DeviceFlowError, match="Polling failed"):
-                        await client.authenticate()
+                    with patch(
+                        "openhands_cli.auth.device_flow.webbrowser.open"
+                    ) as mock_open:
+                        with pytest.raises(DeviceFlowError, match="Polling failed"):
+                            await client.authenticate()
+
+                        mock_open.assert_called_once_with(
+                            "https://example.com/device?user_code=USER123"
+                        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [X] A human has tested these changes.

---

## Why

Running this test can open a browser as a side effect. This is unnecessary for a test run.

## Summary

- mock browser opening in the device flow poll error test to avoid external side effects during test runs

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

Run `uv run pytest -v tests/auth/test_device_flow.py::TestDeviceFlowClient::test_authenticate_poll_error` and verify the test passes without opening a browser.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->