### PR TITLE
tests: prevent unawaited coroutine warnings in async tests

### DIFF
--- a/tests/acp/events/test_token_streamer.py
+++ b/tests/acp/events/test_token_streamer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from acp.schema import (
@@ -663,10 +663,19 @@ class TestScheduleUpdate:
 
         update = update_agent_message_text("test")
 
+        def _run_coroutine_threadsafe(coro, running_loop):
+            coro.close()
+            future = MagicMock()
+            future.result.return_value = None
+            return future
+
         with patch.object(loop, "is_running", return_value=True):
-            with patch("asyncio.run_coroutine_threadsafe") as mock_rcts:
+            with patch(
+                "openhands_cli.acp_impl.events.token_streamer.asyncio.run_coroutine_threadsafe",
+                side_effect=_run_coroutine_threadsafe,
+            ) as mock_rcts:
                 subscriber._schedule_update(update)
-                mock_rcts.assert_called_once()
+                mock_rcts.assert_called_once_with(ANY, loop)
 
         loop.close()
 

--- a/tests/auth/test_login_command.py
+++ b/tests/auth/test_login_command.py
@@ -219,9 +219,13 @@ class TestLoginCommand:
         """Test synchronous wrapper for login command - success case."""
         server_url = "https://api.example.com"
 
-        with patch("openhands_cli.auth.login_command.asyncio.run") as mock_run:
-            mock_run.return_value = True
+        def _run(coro):
+            coro.close()
+            return True
 
+        with patch(
+            "openhands_cli.auth.login_command.asyncio.run", side_effect=_run
+        ) as mock_run:
             result = run_login_command(server_url)
 
             assert result is True
@@ -231,26 +235,36 @@ class TestLoginCommand:
         """Test synchronous wrapper for login command - keyboard interrupt."""
         server_url = "https://api.example.com"
 
-        with patch("openhands_cli.auth.login_command.asyncio.run") as mock_run:
-            with patch("openhands_cli.auth.login_command.console_print") as mock_print:
-                mock_run.side_effect = KeyboardInterrupt()
+        def _run(coro):
+            coro.close()
+            raise KeyboardInterrupt()
 
+        with patch(
+            "openhands_cli.auth.login_command.asyncio.run", side_effect=_run
+        ) as mock_run:
+            with patch("openhands_cli.auth.login_command.console_print") as mock_print:
                 result = run_login_command(server_url)
 
                 assert result is False
                 print_calls = [call[0][0] for call in mock_print.call_args_list]
                 assert any("cancelled by user" in call for call in print_calls)
+                mock_run.assert_called_once()
 
     def test_run_login_command_failure(self):
         """Test synchronous wrapper for login command - failure case."""
         server_url = "https://api.example.com"
 
-        with patch("openhands_cli.auth.login_command.asyncio.run") as mock_run:
-            mock_run.return_value = False
+        def _run(coro):
+            coro.close()
+            return False
 
+        with patch(
+            "openhands_cli.auth.login_command.asyncio.run", side_effect=_run
+        ) as mock_run:
             result = run_login_command(server_url)
 
             assert result is False
+            mock_run.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_login_command_with_successful_token_storage_and_fetch(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -441,7 +441,13 @@ def test_handle_cloud_command_with_task(monkeypatch):
     ) as mock_create_seeded:
         mock_create_seeded.return_value = ["Test task"]
 
-        with patch("asyncio.run") as mock_asyncio_run:
+        def _run(coro):
+            coro.close()
+            return None
+
+        with patch(
+            "openhands_cli.cloud.command.asyncio.run", side_effect=_run
+        ) as mock_asyncio_run:
             with patch("openhands_cli.cloud.command.console_print") as mock_print:
                 handle_cloud_command(args)
 
@@ -453,11 +459,12 @@ def test_handle_cloud_command_with_task(monkeypatch):
 
                 # Verify success message was printed
                 success_calls = [
-                    call
-                    for call in mock_print.call_args_list
-                    if "successfully" in str(call)
+                    str(call.args[0]) for call in mock_print.call_args_list if call.args
                 ]
-                assert len(success_calls) > 0
+                assert any(
+                    "Cloud conversation created successfully!" in call
+                    for call in success_calls
+                )
 
 
 def test_handle_cloud_command_no_initial_message(monkeypatch):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [X] A human has tested these changes.

---

## Why

These tests were emitting `RuntimeWarning` warnings for unawaited coroutines during test runs:

- `coroutine 'TokenBasedEventSubscriber._schedule_update.<locals>._send' was never awaited`
- `coroutine 'login_command' was never awaited`
- `coroutine '_run_cloud_conversation' was never awaited`

## Summary

- close mocked coroutines in async wrapper tests to avoid unawaited coroutine warnings

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

Run:

`uv run pytest -v -W error::RuntimeWarning tests/acp/events/test_token_streamer.py::TestScheduleUpdate::test_schedule_update_loop_running_uses_run_coroutine_threadsafe tests/auth/test_login_command.py::TestLoginCommand::test_run_login_command_success tests/auth/test_login_command.py::TestLoginCommand::test_run_login_command_keyboard_interrupt tests/auth/test_login_command.py::TestLoginCommand::test_run_login_command_failure tests/test_main.py::test_handle_cloud_command_with_task`

and verify the tests pass without `RuntimeWarning` warnings.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

## Notes

Before this change, these tests emitted the following warnings:

- `RuntimeWarning: coroutine 'TokenBasedEventSubscriber._schedule_update.<locals>._send' was never awaited`
- `RuntimeWarning: coroutine 'login_command' was never awaited`
- `RuntimeWarning: coroutine '_run_cloud_conversation' was never awaited`