### PR TITLE
cli: replace prompt_toolkit with rich for styled output

### DIFF
--- a/openhands-cli.spec
+++ b/openhands-cli.spec
@@ -46,7 +46,6 @@ a = Analysis(
     hiddenimports=[
         # Explicitly include modules that might not be detected automatically
         *collect_submodules('openhands_cli'),
-        *collect_submodules('prompt_toolkit'),
         # Include OpenHands SDK submodules explicitly to avoid resolution issues
         *collect_submodules('openhands.sdk'),
         *collect_submodules('openhands.tools'),

--- a/openhands_cli/gui_launcher.py
+++ b/openhands_cli/gui_launcher.py
@@ -6,23 +6,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-from prompt_toolkit import print_formatted_text
-from prompt_toolkit.formatted_text import HTML
+from rich.console import Console
+from rich.markup import escape
 
 from openhands_cli.locations import get_persistence_dir
 
 
+console = Console(highlight=False, soft_wrap=True)
+
+
 def _format_docker_command_for_logging(cmd: list[str]) -> str:
-    """Format a Docker command for logging with grey color.
-
-    Args:
-        cmd (list[str]): The Docker command as a list of strings
-
-    Returns:
-        str: The formatted command string in grey HTML color
-    """
+    """Format a Docker command for logging."""
     cmd_str = " ".join(cmd)
-    return f"<grey>Running Docker command: {cmd_str}</grey>"
+    return f"Running Docker command: {cmd_str}"
 
 
 def check_docker_requirements() -> bool:
@@ -33,13 +29,15 @@ def check_docker_requirements() -> bool:
     """
     # Check if Docker is installed
     if not shutil.which("docker"):
-        print_formatted_text(
-            HTML("<ansired>❌ Docker is not installed or not in PATH.</ansired>")
+        console.print(
+            "❌ Docker is not installed or not in PATH.",
+            style="red",
+            markup=False,
         )
-        print_formatted_text(
-            HTML(
-                "<grey>Please install Docker first: https://docs.docker.com/get-docker/</grey>"
-            )
+        console.print(
+            "Please install Docker first: https://docs.docker.com/get-docker/",
+            style="grey50",
+            markup=False,
         )
         return False
 
@@ -49,18 +47,24 @@ def check_docker_requirements() -> bool:
             ["docker", "info"], capture_output=True, text=True, timeout=10
         )
         if result.returncode != 0:
-            print_formatted_text(
-                HTML("<ansired>❌ Docker daemon is not running.</ansired>")
+            console.print(
+                "❌ Docker daemon is not running.",
+                style="red",
+                markup=False,
             )
-            print_formatted_text(
-                HTML("<grey>Please start Docker and try again.</grey>")
+            console.print(
+                "Please start Docker and try again.",
+                style="grey50",
+                markup=False,
             )
             return False
     except (subprocess.TimeoutExpired, subprocess.SubprocessError) as e:
-        print_formatted_text(
-            HTML("<ansired>❌ Failed to check Docker status.</ansired>")
+        console.print(
+            "❌ Failed to check Docker status.",
+            style="red",
+            markup=False,
         )
-        print_formatted_text(HTML(f"<grey>Error: {e}</grey>"))
+        console.print(f"Error: {e}", style="grey50", markup=False)
         return False
 
     return True
@@ -92,10 +96,8 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
         gpu: If True, enable GPU support by mounting all GPUs into the
             container via nvidia-docker.
     """
-    print_formatted_text(
-        HTML("<ansiblue>🚀 Launching OpenHands GUI server...</ansiblue>")
-    )
-    print_formatted_text("")
+    console.print("🚀 Launching OpenHands GUI server...", style="blue", markup=False)
+    console.print()
 
     # Check Docker requirements
     if not check_docker_requirements():
@@ -113,14 +115,14 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     # tested and compatible with that specific app version. Setting these env vars
     # could cause version mismatches between the app and agent server.
 
-    print_formatted_text(
-        HTML("<ansigreen>✅ Starting OpenHands GUI server...</ansigreen>")
+    console.print("✅ Starting OpenHands GUI server...", style="green", markup=False)
+    console.print(
+        "The server will be available at: http://localhost:3000",
+        style="grey50",
+        markup=False,
     )
-    print_formatted_text(
-        HTML("<grey>The server will be available at: http://localhost:3000</grey>")
-    )
-    print_formatted_text(HTML("<grey>Press Ctrl+C to stop the server.</grey>"))
-    print_formatted_text("")
+    console.print("Press Ctrl+C to stop the server.", style="grey50", markup=False)
+    console.print()
 
     # Build the Docker command
     docker_cmd = [
@@ -139,8 +141,10 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
 
     # Add GPU support if requested
     if gpu:
-        print_formatted_text(
-            HTML("<ansigreen>🖥️ Enabling GPU support via nvidia-docker...</ansigreen>")
+        console.print(
+            "🖥️ Enabling GPU support via nvidia-docker...",
+            style="green",
+            markup=False,
         )
         # Add the --gpus all flag to enable all GPUs
         docker_cmd.insert(2, "--gpus")
@@ -156,7 +160,8 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     # Add current working directory mount if requested
     if mount_cwd:
         cwd = Path.cwd()
-        # Following the documentation at https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem
+        # Following the documentation at
+        # https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem
         docker_cmd.extend(
             [
                 "-e",
@@ -173,12 +178,10 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
                 # If 'id' command fails or doesn't exist, skip setting user ID
                 pass
         # Print the folder that will be mounted to inform the user
-        print_formatted_text(
-            HTML(
-                f"<ansigreen>📂 Mounting current directory:</ansigreen> "
-                f"<ansiyellow>{cwd}</ansiyellow> <ansigreen>to</ansigreen> "
-                f"<ansiyellow>/workspace</ansiyellow>"
-            )
+        console.print(
+            f"[green]📂 Mounting current directory:[/green] "
+            f"[yellow]{escape(str(cwd))}[/yellow] "
+            f"[green]to[/green] [yellow]/workspace[/yellow]"
         )
 
     docker_cmd.extend(
@@ -195,18 +198,26 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
 
     try:
         # Log and run the Docker command
-        print_formatted_text(HTML(_format_docker_command_for_logging(docker_cmd)))
+        console.print(
+            _format_docker_command_for_logging(docker_cmd),
+            style="grey50",
+            markup=False,
+        )
         subprocess.run(docker_cmd, check=True)
     except subprocess.CalledProcessError as e:
-        print_formatted_text("")
-        print_formatted_text(
-            HTML("<ansired>❌ Failed to start OpenHands GUI server.</ansired>")
+        console.print()
+        console.print(
+            "❌ Failed to start OpenHands GUI server.",
+            style="red",
+            markup=False,
         )
-        print_formatted_text(HTML(f"<grey>Error: {e}</grey>"))
+        console.print(f"Error: {e}", style="grey50", markup=False)
         sys.exit(1)
     except KeyboardInterrupt:
-        print_formatted_text("")
-        print_formatted_text(
-            HTML("<ansigreen>✓ OpenHands GUI server stopped successfully.</ansigreen>")
+        console.print()
+        console.print(
+            "✓ OpenHands GUI server stopped successfully.",
+            style="green",
+            markup=False,
         )
         sys.exit(0)

--- a/openhands_cli/gui_launcher.py
+++ b/openhands_cli/gui_launcher.py
@@ -161,7 +161,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     if mount_cwd:
         cwd = Path.cwd()
         # Following the documentation at
-        # https://docs.all-hands.dev/usage/runtimes/docker#connecting-to-your-filesystem
+        # https://docs.openhands.dev/usage/runtimes/docker#connecting-to-your-filesystem
         docker_cmd.extend(
             [
                 "-e",

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -6,7 +6,6 @@ import os
 import re
 from typing import Any
 
-from prompt_toolkit import HTML, print_formatted_text
 from pydantic import BaseModel, SecretStr
 from rich.console import Console
 
@@ -38,6 +37,10 @@ from openhands_cli.utils import (
     get_os_description,
     should_set_litellm_extra_body,
 )
+
+
+console = Console(highlight=False, soft_wrap=True)
+stderr_console = Console(stderr=True, highlight=False, soft_wrap=True)
 
 
 def get_persisted_conversation_tools(conversation_id: str) -> list[Tool] | None:
@@ -273,8 +276,10 @@ class AgentStore:
         except FileNotFoundError:
             return None
         except Exception:
-            print_formatted_text(
-                HTML("\n<red>Agent configuration file is corrupted!</red>")
+            console.print(
+                "\nAgent configuration file is corrupted!",
+                style="red",
+                markup=False,
             )
             return None
 

--- a/openhands_cli/utils.py
+++ b/openhands_cli/utils.py
@@ -8,8 +8,7 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any
 
-from prompt_toolkit import print_formatted_text
-from prompt_toolkit.formatted_text import HTML
+from rich.console import Console
 
 from openhands.sdk import LLM, Agent, ImageContent, TextContent
 from openhands.sdk.event import SystemPromptEvent
@@ -211,7 +210,11 @@ def create_seeded_instructions_from_args(args: Namespace) -> list[str] | None:
         try:
             content = path.read_text(encoding="utf-8")
         except OSError as exc:
-            print_formatted_text(HTML(f"<red>Failed to read file {path}: {exc}</red>"))
+            Console(highlight=False, soft_wrap=True).print(
+                f"Failed to read file {path}: {exc}",
+                style="red",
+                markup=False,
+            )
             raise SystemExit(1)
 
         initial_message = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "openhands-sdk==1.17.0",
   "openhands-tools==1.17.0",
   "openhands-workspace==1.11.1",
-  "prompt-toolkit>=3",
   "rich<14.3.0",
   "textual>=8.0.0,<9.0.0",
   "typer>=0.17.4",

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -23,14 +23,16 @@ class TestFormatDockerCommand:
         [
             (
                 ["docker", "run", "hello-world"],
-                "<grey>Running Docker command: docker run hello-world</grey>",
+                "Running Docker command: docker run hello-world",
             ),
             (
                 ["docker", "run", "-it", "--rm", "-p", "3000:3000", "openhands:latest"],
-                "<grey>Running Docker command: docker run -it --rm -p 3000:3000 "
-                "openhands:latest</grey>",
+                (
+                    "Running Docker command: docker run -it --rm -p 3000:3000 "
+                    "openhands:latest"
+                ),
             ),
-            ([], "<grey>Running Docker command: </grey>"),
+            ([], "Running Docker command: "),
         ],
     )
     def test_format_docker_command(self, cmd, expected):
@@ -74,7 +76,7 @@ class TestCheckDockerRequirements:
             else:
                 mock_run.return_value = run_side_effect
 
-        with patch("openhands_cli.gui_launcher.print_formatted_text") as mock_print:
+        with patch("openhands_cli.gui_launcher.console.print") as mock_print:
             result = check_docker_requirements()
 
         assert result is expected_result
@@ -103,7 +105,7 @@ class TestLaunchGuiServer:
     """Test GUI server launching."""
 
     @patch("openhands_cli.gui_launcher.check_docker_requirements")
-    @patch("openhands_cli.gui_launcher.print_formatted_text")
+    @patch("openhands_cli.gui_launcher.console.print")
     def test_launch_gui_server_docker_not_available(
         self, mock_print, mock_check_docker
     ):
@@ -134,7 +136,7 @@ class TestLaunchGuiServer:
     @patch("subprocess.run")
     @patch("subprocess.check_output")
     @patch("pathlib.Path.cwd")
-    @patch("openhands_cli.gui_launcher.print_formatted_text")
+    @patch("openhands_cli.gui_launcher.console.print")
     def test_launch_gui_server_scenarios(
         self,
         mock_print,

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = "==3.12.*"
 
 [options]
-exclude-newer = "2026-04-13T19:47:40Z"
+exclude-newer = "2026-04-08T13:22:04.171477384Z"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 openhands-tools = false
@@ -1668,7 +1669,6 @@ dependencies = [
     { name = "openhands-sdk" },
     { name = "openhands-tools" },
     { name = "openhands-workspace" },
-    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyperclip" },
     { name = "rich" },
@@ -1708,7 +1708,6 @@ requires-dist = [
     { name = "openhands-sdk", specifier = "==1.17.0" },
     { name = "openhands-tools", specifier = "==1.17.0" },
     { name = "openhands-workspace", specifier = "==1.11.1" },
-    { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "rich", specifier = "<14.3.0" },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [X] A human has tested these changes.

---

## Why

`prompt_toolkit` was only being used for styled terminal output in a few places. The project already uses `rich` for console output, so keeping both adds unnecessary dependency and import overhead.

## Summary

- replace `prompt_toolkit` output formatting with `rich` console output
- remove `prompt_toolkit` as a dependency
- document `uv` 0.11.6 as the minimum supported version for consistent lockfile behavior

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

- use `uv` `0.11.6` or newer
- `make install-dev`
- `uv run pytest tests/test_gui_launcher.py`
- `uv lock` on this branch and verify `uv.lock` does not change
- `uvx --from uv==0.11.6 uv lock` and verify `uv.lock` still does not change

### Additional verification performed

- On `origin/main`, running `uv lock` with newer uv rewrites the old `exclude-newer` header to the current `7 days ago` cutoff and adds `exclude-newer-span = "P7D"`
- In a temporary repro project with `exclude-newer = "3 weeks"` and `idna`, re-locking later with `uv lock --upgrade-package idna` moved the stored cutoff forward and upgraded `idna` as expected

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `uv.lock` timestamp here is expected to reflect the relative cutoff (`now - 7 days`), not the current day of the `uv lock` command.
- Minimum supported `uv` version is `0.11.6`; older versions can serialize `uv.lock` differently around relative `exclude-newer`.
- Contributors should keep `uv` updated for security fixes; this PR documents the minimum version, but does not itself upgrade the tool in local/CI environments.

_This PR description was updated by an AI assistant (OpenHands) on behalf of the user._
