### PR TITLE
build: enforce minimum uv version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This repo contains the current CLI UX, including the Textual TUI and a browser-s
 - `.agents/skills/`: agent guidance for this repo.
 
 ## Setup, Build, and Development Commands
-This repository uses **uv** for dependency management and running tooling (such as in `Makefile`, CI workflows, and `uv.lock`). Use `uv` 0.11.6 or newer for local development; older versions can serialize `uv.lock` differently around relative `exclude-newer`, and contributors should keep `uv` updated for security fixes. Avoid using `pip install ...` directly if possible.
+This repository uses **uv** for dependency management and running tooling (such as in `Makefile`, CI workflows, and `uv.lock`). Use `uv` 0.11.6 or newer for local development; older versions can serialize `uv.lock` differently around relative `exclude-newer`. Avoid using `pip install ...` directly if possible.
 
 - minimum supported `uv` version: `0.11.6`
 - install dependencies: `make install` (runs `uv sync`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@ This repo contains the current CLI UX, including the Textual TUI and a browser-s
 - `.agents/skills/`: agent guidance for this repo.
 
 ## Setup, Build, and Development Commands
-This repository uses **uv** for dependency management and running tooling (such as in `Makefile`, CI workflows, and `uv.lock`). Avoid using `pip install ...` directly if possible.
+This repository uses **uv** for dependency management and running tooling (such as in `Makefile`, CI workflows, and `uv.lock`). Use `uv` 0.11.6 or newer for local development; older versions can serialize `uv.lock` differently around relative `exclude-newer`, and contributors should keep `uv` updated for security fixes. Avoid using `pip install ...` directly if possible.
 
+- minimum supported `uv` version: `0.11.6`
 - install dependencies: `make install` (runs `uv sync`)
 - install dev dependencies: `make install-dev` (runs `uv sync --group dev`)
 - install pre-commit hooks: `uv run pre-commit install` (included in `make build`)

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,17 @@ RED := \033[31m
 CYAN := \033[36m
 UNDERLINE := \033[4m
 RESET := \033[0m
+REQUIRED_UV_VERSION := 0.11.6
 
-.PHONY: help install install-dev test format clean run run-watch check-uv-version build
+.PHONY: help install install-dev test test-snapshots test-binary format clean run run-watch check-uv-version build install-uv lint pre-commit
 
 check-uv-version:
 	@$(ECHO) "$(YELLOW)Checking uv version...$(RESET)"
+	@if ! command -v uv >/dev/null 2>&1; then \
+		$(ECHO) "$(RED)Error: uv is not installed$(RESET)"; \
+		$(ECHO) "$(YELLOW)Install uv first with: make install-uv$(RESET)"; \
+		exit 1; \
+	fi
 	@UV_VERSION=$$(uv --version | cut -d' ' -f2); \
 	REQUIRED_VERSION=$(REQUIRED_UV_VERSION); \
 	if [ "$$(printf '%s\n' "$$REQUIRED_VERSION" "$$UV_VERSION" | sort -V | head -n1)" != "$$REQUIRED_VERSION" ]; then \
@@ -52,44 +58,44 @@ help:
 	@$(ECHO) "  $(CYAN)run$(RESET)               Run the CLI"
 	@$(ECHO) "  $(CYAN)run-watch$(RESET)         Run CLI with auto-restart on file changes"
 
-install:
+install: check-uv-version
 	@$(ECHO) "$(YELLOW)Installing the package...$(RESET)"
 	uv sync
 	@$(ECHO) "$(GREEN)Package installed successfully.$(RESET)"
 
-install-dev:
+install-dev: check-uv-version
 	@$(ECHO) "$(YELLOW)Installing dev dependencies...$(RESET)"
 	uv sync --group dev
 	@$(ECHO) "$(GREEN)Dev dependencies installed successfully.$(RESET)"
 
-test:
+test: check-uv-version
 	@$(ECHO) "$(YELLOW)Run tests...$(RESET)"
 	uv run pytest --ignore=tests/snapshots
 	@$(ECHO) "$(GREEN)Tests completed.$(RESET)"
 
-test-snapshots:
+test-snapshots: check-uv-version
 	@$(ECHO) "$(YELLOW)Run snapshots tests...$(RESET)"
 	uv run pytest tests/snapshots -v
 	@$(ECHO) "$(GREEN)Snapshots tests completed.$(RESET)"
 
-test-binary:
+test-binary: check-uv-version
 	@$(ECHO) "$(YELLOW)Run end-to-end tests...$(RESET)"
 	uv run pytest tui_e2e
 	@$(ECHO) "$(GREEN)End-to-end tests completed.$(RESET)"
 
 test-all: test test-snapshots
 
-lint:
+lint: check-uv-version
 	@$(ECHO) "$(YELLOW)Linting code with uv format...$(RESET)"
 	uv run ruff check openhands_cli/ --fix
 	@$(ECHO) "$(GREEN)Code linted successfully.$(RESET)"
 
-format:
+format: check-uv-version
 	@$(ECHO) "$(YELLOW)Formatting code with uv format...$(RESET)"
 	uv run ruff format openhands_cli/
 	@$(ECHO) "$(GREEN)Code formatted successfully.$(RESET)"
 
-pre-commit:
+pre-commit: check-uv-version
 	@$(ECHO) "$(YELLOW)Run pre-commit...$(RESET)"
 	uv run pre-commit run --all-files
 	@$(ECHO) "$(GREEN)Pre-commit run successfully.$(RESET)"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Run OpenHands agent inside your terminal, favorite IDE, CI pipelines, local brow
 
 ### Using uv (Recommended)
 
-Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).
+Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/) 0.11.6 or newer.
+Keep `uv` updated for security fixes.
 
 ```bash
 uv tool install openhands --python 3.12

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Run OpenHands agent inside your terminal, favorite IDE, CI pipelines, local brow
 ### Using uv (Recommended)
 
 Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/) 0.11.6 or newer.
-Keep `uv` updated for security fixes.
 
 ```bash
 uv tool install openhands --python 3.12


### PR DESCRIPTION
## Why

Follow-up to #666.

After the `prompt_toolkit` removal PR was merged, we confirmed that `uv` version differences matter for how contributors interpret and validate the `uv.lock` `exclude-newer` metadata. This follow-up makes the minimum supported `uv` version explicit and enforces it in the developer workflow.

## Summary

- set `REQUIRED_UV_VERSION := 0.11.6` in `Makefile`
- enforce the minimum `uv` version before install/test/lint/format/pre-commit targets
- document the minimum supported `uv` version in `README.md`
- record the same guidance in `AGENTS.md`

## How to Test

- run `make check-uv-version` with `uv < 0.11.6` and verify it fails
- run `make check-uv-version` with `uv >= 0.11.6` and verify it passes
- confirm `README.md` and `AGENTS.md` both state that `uv 0.11.6` is the minimum supported version

## Evidence

Live checks I ran while preparing this PR:

### 1) Makefile enforcement fails on older uv

```bash
$ make check-uv-version
Checking uv version...
Error: uv version 0.11.1 is less than required 0.11.6
Please update uv with: uv self update
```

### 2) The same check passes on uv 0.11.6

```bash
$ PATH="$tmpbin:$PATH" make check-uv-version
Checking uv version...
uv version 0.11.6 meets requirements
```

(`$tmpbin/uv` was a small wrapper that executed `uvx --from uv==0.11.6 uv "$@"`.)

### 3) Live repro of the `exclude-newer` behavior we discussed on #666

Using a temp project with:

```toml
[tool.uv]
exclude-newer = "3 weeks"
```

and dependency `idna`, I ran `uv lock` twice with simulated timestamps using `UV_TEST_CURRENT_TIMESTAMP` and `uv 0.11.6`:

```text
first exclude-newer: exclude-newer = "2024-04-10T00:00:00Z"
first idna version: version = "3.6"
second exclude-newer: exclude-newer = "2024-05-11T00:00:00Z"
second idna version: version = "3.7"
```

This is the important meaning of the behavior: the lockfile stores the computed cutoff timestamp for the relative span, and when the lock is regenerated later, that cutoff moves forward accordingly. So for this repo, requiring `uv 0.11.6+` makes the expected `uv.lock` behavior clear and reproducible.

## Notes

- This PR documents and enforces the minimum supported `uv` version; it does not change CI workflow pinning.
- Contributors should still keep `uv` updated for security fixes.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@build/enforce-uv-0-11-6
```