### PR TITLE
feat(cli): add /btw side-channel command for asking the agent mid-task

### DIFF
--- a/openhands_cli/acp_impl/slash_commands.py
+++ b/openhands_cli/acp_impl/slash_commands.py
@@ -51,6 +51,13 @@ def get_available_slash_commands() -> list[AvailableCommand]:
                 root=UnstructuredCommandInput(hint=mode_options),
             ),
         ),
+        AvailableCommand(
+            name="btw",
+            description="Ask the agent a side question without derailing the main task",
+            input=AvailableCommandInput(
+                root=UnstructuredCommandInput(hint="Your question"),
+            ),
+        ),
     ]
 
 

--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -79,9 +79,7 @@ class OpenHandsApiClient(BaseHttpClient):
     ) -> httpx.Response:
         return await self.post("/api/v1/app-conversations", self._headers, json_data)
 
-    async def ask_agent(
-        self, conversation_id: str, question: str
-    ) -> dict[str, Any]:
+    async def ask_agent(self, conversation_id: str, question: str) -> dict[str, Any]:
         """Ask the agent a side question without queuing a full turn.
 
         Args:

--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -79,6 +79,26 @@ class OpenHandsApiClient(BaseHttpClient):
     ) -> httpx.Response:
         return await self.post("/api/v1/app-conversations", self._headers, json_data)
 
+    async def ask_agent(
+        self, conversation_id: str, question: str
+    ) -> dict[str, Any]:
+        """Ask the agent a side question without queuing a full turn.
+
+        Args:
+            conversation_id: The conversation ID.
+            question: The side question to ask.
+
+        Returns:
+            Dict containing the agent's response with key "response".
+        """
+        path = f"/api/conversations/{conversation_id}/ask_agent"
+        response = await self.post(
+            path,
+            self._headers,
+            json_data={"question": question},
+        )
+        return response.json()
+
     async def get_conversation_info(
         self, conversation_id: str, endpoint: str = ""
     ) -> dict[str, Any] | None:

--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -97,6 +97,7 @@ class OpenHandsApiClient(BaseHttpClient):
             self._headers,
             json_data={"question": question},
         )
+        response.raise_for_status()
         return response.json()
 
     async def get_conversation_info(

--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -88,12 +88,24 @@ class OpenHandsApiClient(BaseHttpClient):
 
         Returns:
             Dict containing the agent's response with key "response".
+
+        Raises:
+            ValueError: If the question is empty or exceeds the length limit.
         """
+        stripped = question.strip()
+        if not stripped:
+            raise ValueError("Question cannot be empty.")
+        max_length = 4096
+        if len(stripped) > max_length:
+            raise ValueError(
+                f"Question exceeds maximum length of {max_length} characters."
+            )
+
         path = f"/api/conversations/{conversation_id}/ask_agent"
         response = await self.post(
             path,
             self._headers,
-            json_data={"question": question},
+            json_data={"question": stripped},
         )
         response.raise_for_status()
         return response.json()

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -1,0 +1,121 @@
+"""BTW (By The Way) interceptor for handling side-channel questions.
+
+This module provides a function that intercepts /btw commands and routes them
+through the ask_agent side-channel without disrupting the main task flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openhands_cli.tui.core.btw_store import BtwEntry
+
+
+# The /btw command prefix
+BTW_COMMAND = "/btw"
+BTW_PREFIX = f"{BTW_COMMAND} "
+
+
+@dataclass
+class BtwResult:
+    """Result of processing a message through the BTW interceptor."""
+    is_btw: bool
+    question: str | None = None
+    entry_id: str | None = None
+
+
+class BtwInterceptor:
+    """Interceptor for /btw commands.
+
+    This interceptor checks if a message starts with /btw and if so,
+    handles it as a side-channel question instead of a regular message.
+    """
+
+    def __init__(
+        self,
+        conversation_id: str | None,
+        ask_agent_callback: callable,
+        get_btw_store: callable,
+    ) -> None:
+        """Initialize the BTW interceptor.
+
+        Args:
+            conversation_id: The current conversation ID.
+            ask_agent_callback: Callback to call the ask_agent API.
+            get_btw_store: Function to get the BTW store.
+        """
+        self._conversation_id = conversation_id
+        self._ask_agent_callback = ask_agent_callback
+        self._get_btw_store = get_btw_store
+
+    def process(self, message: str) -> BtwResult:
+        """Process a message to check if it's a BTW command.
+
+        Args:
+            message: The user's message.
+
+        Returns:
+            BtwResult indicating if it's a BTW command and details.
+        """
+        trimmed = message.strip()
+        is_btw = trimmed == BTW_COMMAND or trimmed.startswith(BTW_PREFIX)
+
+        # If no conversation ID or not a BTW command, passthrough
+        if not self._conversation_id or not is_btw:
+            return BtwResult(is_btw=False)
+
+        # Extract the question
+        question = trimmed[len(BTW_COMMAND):].strip()
+        if not question:
+            # /btw with no question - ignore
+            return BtwResult(is_btw=False)
+
+        # Add pending entry to store
+        store = self._get_btw_store()
+        entry_id = store.add_pending(self._conversation_id, question)
+
+        return BtwResult(
+            is_btw=True,
+            question=question,
+            entry_id=entry_id,
+        )
+
+    async def resolve(self, entry_id: str, response: str) -> None:
+        """Resolve a BTW entry with the agent's response.
+
+        Args:
+            entry_id: The entry ID to resolve.
+            response: The agent's response.
+        """
+        store = self._get_btw_store()
+        store.resolve(self._conversation_id, entry_id, response)
+
+    async def fail(self, entry_id: str, error: str) -> None:
+        """Mark a BTW entry as failed.
+
+        Args:
+            entry_id: The entry ID that failed.
+            error: The error message.
+        """
+        store = self._get_btw_store()
+        store.fail(self._conversation_id, entry_id, error)
+
+    def get_entries(self) -> list[BtwEntry]:
+        """Get all BTW entries for the current conversation.
+
+        Returns:
+            List of BTW entries.
+        """
+        store = self._get_btw_store()
+        return store.get_entries(self._conversation_id)
+
+    def dismiss(self, entry_id: str) -> None:
+        """Dismiss a BTW entry.
+
+        Args:
+            entry_id: The entry ID to dismiss.
+        """
+        store = self._get_btw_store()
+        store.dismiss(self._conversation_id, entry_id)

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -75,16 +75,24 @@ class BtwInterceptor:
 
     async def resolve(self, entry_id: str, response: str) -> None:
         """Resolve a BTW entry with the agent's response."""
+        if self._conversation_id is None:
+            return
         self._store.resolve(self._conversation_id, entry_id, response)
 
     async def fail(self, entry_id: str, error: str) -> None:
         """Mark a BTW entry as failed."""
+        if self._conversation_id is None:
+            return
         self._store.fail(self._conversation_id, entry_id, error)
 
     def get_entries(self) -> list[BtwEntry]:
         """Get all BTW entries for the current conversation."""
+        if self._conversation_id is None:
+            return []
         return self._store.get_entries(self._conversation_id)
 
     def dismiss(self, entry_id: str) -> None:
         """Dismiss a BTW entry."""
+        if self._conversation_id is None:
+            return
         self._store.dismiss(self._conversation_id, entry_id)

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -50,6 +50,14 @@ class BtwInterceptor:
         self._ask_agent_callback = ask_agent_callback
         self._get_btw_store = get_btw_store
 
+    def set_conversation_id(self, conversation_id: str | None) -> None:
+        """Update the conversation ID.
+
+        Args:
+            conversation_id: The new conversation ID.
+        """
+        self._conversation_id = conversation_id
+
     def process(self, message: str) -> BtwResult:
         """Process a message to check if it's a BTW command.
 

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -6,8 +6,10 @@ through the ask_agent side-channel without disrupting the main task flow.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
+
 
 if TYPE_CHECKING:
     from openhands_cli.tui.core.btw_store import BtwEntry

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -1,14 +1,15 @@
 """BTW (By The Way) interceptor for handling side-channel questions.
 
-This module provides a function that intercepts /btw commands and routes them
+This module provides a class that intercepts /btw commands and routes them
 through the ask_agent side-channel without disrupting the main task flow.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from openhands_cli.tui.core.btw_store import BtwStore
 
 
 if TYPE_CHECKING:
@@ -32,40 +33,24 @@ class BtwResult:
 class BtwInterceptor:
     """Interceptor for /btw commands.
 
-    This interceptor checks if a message starts with /btw and if so,
-    handles it as a side-channel question instead of a regular message.
+    Handles command parsing and store management for side-channel questions.
+    The actual API call is the caller's responsibility.
     """
 
     def __init__(
         self,
-        conversation_id: str | None,
-        ask_agent_callback: Callable[[str, str], Any],
-        get_btw_store: Callable[[], Any],
+        store: BtwStore,
+        conversation_id: str | None = None,
     ) -> None:
-        """Initialize the BTW interceptor.
-
-        Args:
-            conversation_id: The current conversation ID.
-            ask_agent_callback: Callback to call the ask_agent API.
-            get_btw_store: Function to get the BTW store.
-        """
+        self._store = store
         self._conversation_id = conversation_id
-        self._ask_agent_callback = ask_agent_callback
-        self._get_btw_store = get_btw_store
 
     def set_conversation_id(self, conversation_id: str | None) -> None:
-        """Update the conversation ID.
-
-        Args:
-            conversation_id: The new conversation ID.
-        """
+        """Update the conversation ID."""
         self._conversation_id = conversation_id
 
     def process(self, message: str) -> BtwResult:
         """Process a message to check if it's a BTW command.
-
-        Args:
-            message: The user's message.
 
         Returns:
             BtwResult indicating if it's a BTW command and details.
@@ -73,19 +58,14 @@ class BtwInterceptor:
         trimmed = message.strip()
         is_btw = trimmed == BTW_COMMAND or trimmed.startswith(BTW_PREFIX)
 
-        # If no conversation ID or not a BTW command, passthrough
         if not self._conversation_id or not is_btw:
             return BtwResult(is_btw=False)
 
-        # Extract the question
         question = trimmed[len(BTW_COMMAND) :].strip()
         if not question:
-            # /btw with no question - ignore
             return BtwResult(is_btw=False)
 
-        # Add pending entry to store
-        store = self._get_btw_store()
-        entry_id = store.add_pending(self._conversation_id, question)
+        entry_id = self._store.add_pending(self._conversation_id, question)
 
         return BtwResult(
             is_btw=True,
@@ -94,39 +74,17 @@ class BtwInterceptor:
         )
 
     async def resolve(self, entry_id: str, response: str) -> None:
-        """Resolve a BTW entry with the agent's response.
-
-        Args:
-            entry_id: The entry ID to resolve.
-            response: The agent's response.
-        """
-        store = self._get_btw_store()
-        store.resolve(self._conversation_id, entry_id, response)
+        """Resolve a BTW entry with the agent's response."""
+        self._store.resolve(self._conversation_id, entry_id, response)
 
     async def fail(self, entry_id: str, error: str) -> None:
-        """Mark a BTW entry as failed.
-
-        Args:
-            entry_id: The entry ID that failed.
-            error: The error message.
-        """
-        store = self._get_btw_store()
-        store.fail(self._conversation_id, entry_id, error)
+        """Mark a BTW entry as failed."""
+        self._store.fail(self._conversation_id, entry_id, error)
 
     def get_entries(self) -> list[BtwEntry]:
-        """Get all BTW entries for the current conversation.
-
-        Returns:
-            List of BTW entries.
-        """
-        store = self._get_btw_store()
-        return store.get_entries(self._conversation_id)
+        """Get all BTW entries for the current conversation."""
+        return self._store.get_entries(self._conversation_id)
 
     def dismiss(self, entry_id: str) -> None:
-        """Dismiss a BTW entry.
-
-        Args:
-            entry_id: The entry ID to dismiss.
-        """
-        store = self._get_btw_store()
-        store.dismiss(self._conversation_id, entry_id)
+        """Dismiss a BTW entry."""
+        self._store.dismiss(self._conversation_id, entry_id)

--- a/openhands_cli/tui/core/btw_interceptor.py
+++ b/openhands_cli/tui/core/btw_interceptor.py
@@ -7,7 +7,7 @@ through the ask_agent side-channel without disrupting the main task flow.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from openhands_cli.tui.core.btw_store import BtwEntry
@@ -21,6 +21,7 @@ BTW_PREFIX = f"{BTW_COMMAND} "
 @dataclass
 class BtwResult:
     """Result of processing a message through the BTW interceptor."""
+
     is_btw: bool
     question: str | None = None
     entry_id: str | None = None
@@ -36,8 +37,8 @@ class BtwInterceptor:
     def __init__(
         self,
         conversation_id: str | None,
-        ask_agent_callback: callable,
-        get_btw_store: callable,
+        ask_agent_callback: Callable[[str, str], Any],
+        get_btw_store: Callable[[], Any],
     ) -> None:
         """Initialize the BTW interceptor.
 
@@ -75,7 +76,7 @@ class BtwInterceptor:
             return BtwResult(is_btw=False)
 
         # Extract the question
-        question = trimmed[len(BTW_COMMAND):].strip()
+        question = trimmed[len(BTW_COMMAND) :].strip()
         if not question:
             # /btw with no question - ignore
             return BtwResult(is_btw=False)

--- a/openhands_cli/tui/core/btw_store.py
+++ b/openhands_cli/tui/core/btw_store.py
@@ -121,15 +121,3 @@ class BtwStore:
             self._entries_by_conversation.clear()
         elif conversation_id in self._entries_by_conversation:
             del self._entries_by_conversation[conversation_id]
-
-
-# Global singleton instance
-_btw_store: BtwStore | None = None
-
-
-def get_btw_store() -> BtwStore:
-    """Get the global BTW store instance."""
-    global _btw_store
-    if _btw_store is None:
-        _btw_store = BtwStore()
-    return _btw_store

--- a/openhands_cli/tui/core/btw_store.py
+++ b/openhands_cli/tui/core/btw_store.py
@@ -1,0 +1,135 @@
+"""BTW (By The Way) store for tracking side-channel questions.
+
+This module provides a store for managing BTW entries - questions that users
+ask via /btw command without disrupting the main task flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class BtwStatus(Enum):
+    """Status of a BTW entry."""
+    PENDING = "pending"
+    DONE = "done"
+    ERROR = "error"
+
+
+@dataclass
+class BtwEntry:
+    """A single BTW entry representing a side-channel question."""
+    id: str
+    question: str
+    response: str | None = None
+    status: BtwStatus = BtwStatus.PENDING
+
+
+class BtwStore:
+    """Store for BTW entries scoped to conversations.
+
+    This is a simple in-memory store that tracks pending, resolved, and failed
+    BTW entries per conversation.
+    """
+
+    def __init__(self) -> None:
+        self._entries_by_conversation: dict[str, list[BtwEntry]] = {}
+
+    def add_pending(self, conversation_id: str, question: str) -> str:
+        """Add a pending BTW entry.
+
+        Args:
+            conversation_id: The conversation ID.
+            question: The question to ask.
+
+        Returns:
+            The ID of the new entry.
+        """
+        import uuid
+
+        entry_id = str(uuid.uuid4())
+        entries = self._entries_by_conversation.setdefault(conversation_id, [])
+        entries.append(BtwEntry(id=entry_id, question=question, status=BtwStatus.PENDING))
+        return entry_id
+
+    def resolve(self, conversation_id: str, entry_id: str, response: str) -> None:
+        """Mark a BTW entry as resolved.
+
+        Args:
+            conversation_id: The conversation ID.
+            entry_id: The entry ID.
+            response: The agent's response.
+        """
+        entries = self._entries_by_conversation.get(conversation_id, [])
+        for entry in entries:
+            if entry.id == entry_id:
+                entry.response = response
+                entry.status = BtwStatus.DONE
+                break
+
+    def fail(self, conversation_id: str, entry_id: str, error: str) -> None:
+        """Mark a BTW entry as failed.
+
+        Args:
+            conversation_id: The conversation ID.
+            entry_id: The entry ID.
+            error: The error message.
+        """
+        entries = self._entries_by_conversation.get(conversation_id, [])
+        for entry in entries:
+            if entry.id == entry_id:
+                entry.response = error
+                entry.status = BtwStatus.ERROR
+                break
+
+    def dismiss(self, conversation_id: str, entry_id: str) -> None:
+        """Dismiss (remove) a BTW entry.
+
+        Args:
+            conversation_id: The conversation ID.
+            entry_id: The entry ID to dismiss.
+        """
+        entries = self._entries_by_conversation.get(conversation_id, [])
+        self._entries_by_conversation[conversation_id] = [
+            e for e in entries if e.id != entry_id
+        ]
+
+    def get_entries(self, conversation_id: str) -> list[BtwEntry]:
+        """Get all BTW entries for a conversation.
+
+        Args:
+            conversation_id: The conversation ID.
+
+        Returns:
+            List of BTW entries.
+        """
+        return list(self._entries_by_conversation.get(conversation_id, []))
+
+    def clear(self, conversation_id: str | None = None) -> None:
+        """Clear BTW entries.
+
+        Args:
+            conversation_id: If provided, clear only entries for this conversation.
+                           If None, clear all entries.
+        """
+        if conversation_id is None:
+            self._entries_by_conversation.clear()
+        elif conversation_id in self._entries_by_conversation:
+            del self._entries_by_conversation[conversation_id]
+
+
+# Global singleton instance
+_btw_store: BtwStore | None = None
+
+
+def get_btw_store() -> BtwStore:
+    """Get the global BTW store instance."""
+    global _btw_store
+    if _btw_store is None:
+        _btw_store = BtwStore()
+    return _btw_store

--- a/openhands_cli/tui/core/btw_store.py
+++ b/openhands_cli/tui/core/btw_store.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 class BtwStatus(Enum):
     """Status of a BTW entry."""
+
     PENDING = "pending"
     DONE = "done"
     ERROR = "error"
@@ -20,6 +21,7 @@ class BtwStatus(Enum):
 @dataclass
 class BtwEntry:
     """A single BTW entry representing a side-channel question."""
+
     id: str
     question: str
     response: str | None = None
@@ -50,7 +52,9 @@ class BtwStore:
 
         entry_id = str(uuid.uuid4())
         entries = self._entries_by_conversation.setdefault(conversation_id, [])
-        entries.append(BtwEntry(id=entry_id, question=question, status=BtwStatus.PENDING))
+        entries.append(
+            BtwEntry(id=entry_id, question=question, status=BtwStatus.PENDING)
+        )
         return entry_id
 
     def resolve(self, conversation_id: str, entry_id: str, response: str) -> None:

--- a/openhands_cli/tui/core/btw_store.py
+++ b/openhands_cli/tui/core/btw_store.py
@@ -6,12 +6,8 @@ ask via /btw command without disrupting the main task flow.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
 
 class BtwStatus(Enum):

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -40,6 +40,11 @@ from openhands_cli.tui.messages import (
     SendMessage,
     SendRefinementMessage,
 )
+from openhands_cli.tui.core.btw_interceptor import (
+    BTW_COMMAND,
+    BtwInterceptor,
+    get_btw_store,
+)
 
 
 if TYPE_CHECKING:
@@ -176,6 +181,33 @@ class ConversationManager(Container):
             run_worker=self.run_worker,
         )
 
+        # Initialize BTW interceptor for side-channel questions
+        # Note: api_client will be set when needed via set_api_client()
+        self._btw_interceptor: BtwInterceptor | None = None
+        self._api_client = None
+
+    def set_api_client(self, api_client, server_url: str | None = None) -> None:
+        """Set the API client for BTW functionality.
+
+        Args:
+            api_client: The API client instance for making requests.
+            server_url: Optional server URL for the API.
+        """
+        self._api_client = api_client
+
+        # Create the BTW interceptor with the conversation ID from state
+        conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+
+        async def ask_agent_callback(conv_id: str, question: str) -> dict:
+            """Callback to call the ask_agent API."""
+            return await api_client.ask_agent(conv_id, question)
+
+        self._btw_interceptor = BtwInterceptor(
+            conversation_id=conversation_id,
+            ask_agent_callback=ask_agent_callback,
+            get_btw_store=get_btw_store,
+        )
+
     # ---- Properties ----
 
     @property
@@ -195,12 +227,65 @@ class ConversationManager(Container):
         """Handle SendMessage - the primary entry point for user messages.
 
         This handler:
-        1. Resets the refinement iteration counter (new user turn)
-        2. Delegates to UserMessageController for rendering and processing
+        1. Checks for /btw (side-channel) commands and handles them separately
+        2. Resets the refinement iteration counter (new user turn)
+        3. Delegates to UserMessageController for rendering and processing
         """
         event.stop()
         self._refinement_controller.reset_iteration()
+
+        # Check for BTW (side-channel) command
+        if self._btw_interceptor is not None:
+            # Update conversation ID in case it changed
+            self._btw_interceptor._conversation_id = (
+                str(self._state.conversation_id) if self._state.conversation_id else None
+            )
+            result = self._btw_interceptor.process(event.content)
+
+            if result.is_btw and result.entry_id:
+                # Handle BTW command - call the API asynchronously
+                self._handle_btw_message(event.content, result.question, result.entry_id)
+                return  # Don't process as regular message
+
         await self._message_controller.handle_user_message(event.content)
+
+    async def _handle_btw_message(
+        self,
+        original_message: str,
+        question: str | None,
+        entry_id: str,
+    ) -> None:
+        """Handle a BTW (side-channel) message by calling the ask_agent API.
+
+        Args:
+            original_message: The original user message.
+            question: The extracted question.
+            entry_id: The BTW entry ID.
+        """
+        if self._btw_interceptor is None:
+            return
+
+        try:
+            conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+            if not conversation_id:
+                await self._btw_interceptor.fail(entry_id, "No conversation ID")
+                return
+
+            response = await self._api_client.ask_agent(conversation_id, question)
+            await self._btw_interceptor.resolve(entry_id, response.get("response", ""))
+
+            # Notify user that BTW response is available
+            self.notify(
+                f"BTW response: {response.get('response', '')}",
+                title="Side Channel Response",
+            )
+        except Exception as e:
+            await self._btw_interceptor.fail(entry_id, str(e))
+            self.notify(
+                f"BTW failed: {e}",
+                title="Error",
+                severity="error",
+            )
 
     @on(SendRefinementMessage)
     async def _on_send_refinement_message(self, event: SendRefinementMessage) -> None:

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -18,10 +18,8 @@ from textual.message import Message
 
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
 from openhands_cli.conversations.protocols import ConversationStore
-from openhands_cli.tui.core.btw_interceptor import (
-    BtwInterceptor,
-    get_btw_store,
-)
+from openhands_cli.tui.core.btw_interceptor import BtwInterceptor
+from openhands_cli.tui.core.btw_store import get_btw_store
 from openhands_cli.tui.core.confirmation_flow_controller import (
     ConfirmationFlowController,
 )
@@ -48,7 +46,6 @@ from openhands_cli.tui.messages import (
 
 if TYPE_CHECKING:
     from openhands_cli.auth.api_client import OpenHandsApiClient
-    from openhands_cli.tui.core.btw_store import BtwStore
     from openhands_cli.tui.core.conversation_runner import ConversationRunner
     from openhands_cli.tui.core.state import ConversationContainer
 

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -182,7 +182,7 @@ class ConversationManager(Container):
         )
 
         # Initialize BTW interceptor for side-channel questions
-        # Note: api_client will be set when needed via set_api_client()
+        # Note: api_client will be lazily initialized on first /btw use
         self._btw_interceptor: BtwInterceptor | None = None
         self._api_client = None
 
@@ -235,9 +235,18 @@ class ConversationManager(Container):
         self._refinement_controller.reset_iteration()
 
         # Check for BTW (side-channel) command
+        # Initialize lazily if not done yet
+        if self._btw_interceptor is None:
+            # Try to initialize API client (will fail if not authenticated)
+            try:
+                self._init_api_client()
+            except RuntimeError:
+                # Not authenticated, skip BTW handling
+                pass
+
         if self._btw_interceptor is not None:
             # Update conversation ID in case it changed
-            self._btw_interceptor._conversation_id = (
+            self._btw_interceptor.set_conversation_id(
                 str(self._state.conversation_id) if self._state.conversation_id else None
             )
             result = self._btw_interceptor.process(event.content)
@@ -271,6 +280,10 @@ class ConversationManager(Container):
                 await self._btw_interceptor.fail(entry_id, "No conversation ID")
                 return
 
+            # Lazy initialization of API client if not set
+            if self._api_client is None:
+                self._init_api_client()
+
             response = await self._api_client.ask_agent(conversation_id, question)
             await self._btw_interceptor.resolve(entry_id, response.get("response", ""))
 
@@ -286,6 +299,41 @@ class ConversationManager(Container):
                 title="Error",
                 severity="error",
             )
+
+    def _init_api_client(self) -> None:
+        """Initialize the API client lazily on first use."""
+        import os
+
+        from openhands_cli.auth.api_client import OpenHandsApiClient
+        from openhands_cli.auth.token_storage import TokenStorage
+
+        # Get credentials
+        token_storage = TokenStorage()
+        api_key = token_storage.get_api_key()
+
+        if not api_key:
+            raise RuntimeError(
+                "Not authenticated. Please run 'openhands login' first."
+            )
+
+        # Get server URL from environment or use default
+        server_url = os.getenv("OPENHANDS_CLOUD_URL", "https://app.all-hands.dev")
+
+        # Create API client
+        self._api_client = OpenHandsApiClient(server_url, api_key)
+
+        # Initialize BTW interceptor with the api_client
+        conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+
+        async def ask_agent_callback(conv_id: str, question: str) -> dict:
+            """Callback to call the ask_agent API."""
+            return await self._api_client.ask_agent(conv_id, question)
+
+        self._btw_interceptor = BtwInterceptor(
+            conversation_id=conversation_id,
+            ask_agent_callback=ask_agent_callback,
+            get_btw_store=get_btw_store,
+        )
 
     @on(SendRefinementMessage)
     async def _on_send_refinement_message(self, event: SendRefinementMessage) -> None:

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -212,16 +212,12 @@ class ConversationManager(Container):
 
         # Check for BTW (side-channel) command
         self._btw_interceptor.set_conversation_id(
-            str(self._state.conversation_id)
-            if self._state.conversation_id
-            else None
+            str(self._state.conversation_id) if self._state.conversation_id else None
         )
         result = self._btw_interceptor.process(event.content)
 
         if result.is_btw and result.entry_id:
-            self.run_worker(
-                self._handle_btw_message(result.question, result.entry_id)
-            )
+            self.run_worker(self._handle_btw_message(result.question, result.entry_id))
             return  # Don't process as regular message
 
         await self._message_controller.handle_user_message(event.content)
@@ -255,9 +251,7 @@ class ConversationManager(Container):
             await self._btw_interceptor.resolve(entry_id, response_text)
 
             display_text = (
-                response_text[:200] + "…"
-                if len(response_text) > 200
-                else response_text
+                response_text[:200] + "…" if len(response_text) > 200 else response_text
             )
             self.notify(
                 f"BTW response: {display_text}",

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -19,7 +19,7 @@ from textual.message import Message
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
 from openhands_cli.conversations.protocols import ConversationStore
 from openhands_cli.tui.core.btw_interceptor import BtwInterceptor
-from openhands_cli.tui.core.btw_store import get_btw_store
+from openhands_cli.tui.core.btw_store import BtwStore
 from openhands_cli.tui.core.confirmation_flow_controller import (
     ConfirmationFlowController,
 )
@@ -179,34 +179,10 @@ class ConversationManager(Container):
             run_worker=self.run_worker,
         )
 
-        # Initialize BTW interceptor for side-channel questions
-        # Note: api_client will be lazily initialized on first /btw use
-        self._btw_interceptor: BtwInterceptor | None = None
+        # BTW side-channel: interceptor is created eagerly, API client lazily
+        self._btw_store = BtwStore()
+        self._btw_interceptor = BtwInterceptor(store=self._btw_store)
         self._api_client: OpenHandsApiClient | None = None
-
-    def set_api_client(self, api_client, server_url: str | None = None) -> None:  # noqa: ARG002
-        """Set the API client for BTW functionality.
-
-        Args:
-            api_client: The API client instance for making requests.
-            server_url: Optional server URL (unused, kept for API compatibility).
-        """
-        self._api_client = api_client
-
-        # Create the BTW interceptor with the conversation ID from state
-        conversation_id = (
-            str(self._state.conversation_id) if self._state.conversation_id else None
-        )
-
-        async def ask_agent_callback(conv_id: str, question: str) -> dict:
-            """Callback to call the ask_agent API."""
-            return await api_client.ask_agent(conv_id, question)
-
-        self._btw_interceptor = BtwInterceptor(
-            conversation_id=conversation_id,
-            ask_agent_callback=ask_agent_callback,
-            get_btw_store=get_btw_store,
-        )
 
     # ---- Properties ----
 
@@ -235,52 +211,27 @@ class ConversationManager(Container):
         self._refinement_controller.reset_iteration()
 
         # Check for BTW (side-channel) command
-        # Initialize lazily if not done yet
-        if self._btw_interceptor is None:
-            # Try to initialize API client (will fail if not authenticated)
-            try:
-                self._init_api_client()
-            except RuntimeError:
-                # Not authenticated, skip BTW handling
-                pass
+        self._btw_interceptor.set_conversation_id(
+            str(self._state.conversation_id)
+            if self._state.conversation_id
+            else None
+        )
+        result = self._btw_interceptor.process(event.content)
 
-        if self._btw_interceptor is not None:
-            # Update conversation ID in case it changed
-            self._btw_interceptor.set_conversation_id(
-                str(self._state.conversation_id)
-                if self._state.conversation_id
-                else None
+        if result.is_btw and result.entry_id:
+            self.run_worker(
+                self._handle_btw_message(result.question, result.entry_id)
             )
-            result = self._btw_interceptor.process(event.content)
-
-            if result.is_btw and result.entry_id:
-                # Handle BTW command - run asynchronously without blocking
-                self.run_worker(
-                    self._handle_btw_message(
-                        event.content, result.question, result.entry_id
-                    )
-                )
-                return  # Don't process as regular message
+            return  # Don't process as regular message
 
         await self._message_controller.handle_user_message(event.content)
 
     async def _handle_btw_message(
         self,
-        original_message: str,  # noqa: ARG002
         question: str | None,
         entry_id: str,
     ) -> None:
-        """Handle a BTW (side-channel) message by calling the ask_agent API.
-
-        Args:
-            original_message: The original user message.
-            question: The extracted question.
-            entry_id: The BTW entry ID.
-        """
-        if self._btw_interceptor is None:
-            return
-
-        # Ensure question is not None at this point
+        """Handle a BTW (side-channel) message by calling the ask_agent API."""
         if question is None:
             await self._btw_interceptor.fail(entry_id, "No question provided")
             return
@@ -295,17 +246,21 @@ class ConversationManager(Container):
                 await self._btw_interceptor.fail(entry_id, "No conversation ID")
                 return
 
-            # Lazy initialization of API client if not set
             if self._api_client is None:
-                self._init_api_client()
+                self._ensure_api_client()
 
             assert self._api_client is not None
             response = await self._api_client.ask_agent(conversation_id, question)
-            await self._btw_interceptor.resolve(entry_id, response.get("response", ""))
+            response_text = response.get("response", "")
+            await self._btw_interceptor.resolve(entry_id, response_text)
 
-            # Notify user that BTW response is available
+            display_text = (
+                response_text[:200] + "…"
+                if len(response_text) > 200
+                else response_text
+            )
             self.notify(
-                f"BTW response: {response.get('response', '')}",
+                f"BTW response: {display_text}",
                 title="Side Channel Response",
             )
         except Exception as e:
@@ -316,41 +271,21 @@ class ConversationManager(Container):
                 severity="error",
             )
 
-    def _init_api_client(self) -> None:
-        """Initialize the API client lazily on first use."""
+    def _ensure_api_client(self) -> None:
+        """Initialize the API client lazily on first /btw use."""
         import os
 
         from openhands_cli.auth.api_client import OpenHandsApiClient
         from openhands_cli.auth.token_storage import TokenStorage
 
-        # Get credentials
         token_storage = TokenStorage()
         api_key = token_storage.get_api_key()
 
         if not api_key:
             raise RuntimeError("Not authenticated. Please run 'openhands login' first.")
 
-        # Get server URL from environment or use default
         server_url = os.getenv("OPENHANDS_CLOUD_URL", "https://app.all-hands.dev")
-
-        # Create API client
         self._api_client = OpenHandsApiClient(server_url, api_key)
-
-        # Initialize BTW interceptor with the api_client
-        conversation_id = (
-            str(self._state.conversation_id) if self._state.conversation_id else None
-        )
-
-        async def ask_agent_callback(conv_id: str, question: str) -> dict:
-            """Callback to call the ask_agent API."""
-            assert self._api_client is not None
-            return await self._api_client.ask_agent(conv_id, question)
-
-        self._btw_interceptor = BtwInterceptor(
-            conversation_id=conversation_id,
-            ask_agent_callback=ask_agent_callback,
-            get_btw_store=get_btw_store,
-        )
 
     @on(SendRefinementMessage)
     async def _on_send_refinement_message(self, event: SendRefinementMessage) -> None:

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -18,6 +18,10 @@ from textual.message import Message
 
 from openhands.sdk.security.confirmation_policy import ConfirmationPolicyBase
 from openhands_cli.conversations.protocols import ConversationStore
+from openhands_cli.tui.core.btw_interceptor import (
+    BtwInterceptor,
+    get_btw_store,
+)
 from openhands_cli.tui.core.confirmation_flow_controller import (
     ConfirmationFlowController,
 )
@@ -39,11 +43,6 @@ from openhands_cli.tui.messages import (
     CriticResultReceived,
     SendMessage,
     SendRefinementMessage,
-)
-from openhands_cli.tui.core.btw_interceptor import (
-    BTW_COMMAND,
-    BtwInterceptor,
-    get_btw_store,
 )
 
 
@@ -186,17 +185,19 @@ class ConversationManager(Container):
         self._btw_interceptor: BtwInterceptor | None = None
         self._api_client = None
 
-    def set_api_client(self, api_client, server_url: str | None = None) -> None:
+    def set_api_client(self, api_client, server_url: str | None = None) -> None:  # noqa: ARG002
         """Set the API client for BTW functionality.
 
         Args:
             api_client: The API client instance for making requests.
-            server_url: Optional server URL for the API.
+            server_url: Optional server URL for the API (unused, kept for API compatibility).
         """
         self._api_client = api_client
 
         # Create the BTW interceptor with the conversation ID from state
-        conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+        conversation_id = (
+            str(self._state.conversation_id) if self._state.conversation_id else None
+        )
 
         async def ask_agent_callback(conv_id: str, question: str) -> dict:
             """Callback to call the ask_agent API."""
@@ -247,20 +248,24 @@ class ConversationManager(Container):
         if self._btw_interceptor is not None:
             # Update conversation ID in case it changed
             self._btw_interceptor.set_conversation_id(
-                str(self._state.conversation_id) if self._state.conversation_id else None
+                str(self._state.conversation_id)
+                if self._state.conversation_id
+                else None
             )
             result = self._btw_interceptor.process(event.content)
 
             if result.is_btw and result.entry_id:
                 # Handle BTW command - call the API asynchronously
-                self._handle_btw_message(event.content, result.question, result.entry_id)
+                self._handle_btw_message(
+                    event.content, result.question, result.entry_id
+                )
                 return  # Don't process as regular message
 
         await self._message_controller.handle_user_message(event.content)
 
     async def _handle_btw_message(
         self,
-        original_message: str,
+        original_message: str,  # noqa: ARG002
         question: str | None,
         entry_id: str,
     ) -> None:
@@ -274,8 +279,17 @@ class ConversationManager(Container):
         if self._btw_interceptor is None:
             return
 
+        # Ensure question is not None at this point
+        if question is None:
+            await self._btw_interceptor.fail(entry_id, "No question provided")
+            return
+
         try:
-            conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+            conversation_id = (
+                str(self._state.conversation_id)
+                if self._state.conversation_id
+                else None
+            )
             if not conversation_id:
                 await self._btw_interceptor.fail(entry_id, "No conversation ID")
                 return
@@ -312,9 +326,7 @@ class ConversationManager(Container):
         api_key = token_storage.get_api_key()
 
         if not api_key:
-            raise RuntimeError(
-                "Not authenticated. Please run 'openhands login' first."
-            )
+            raise RuntimeError("Not authenticated. Please run 'openhands login' first.")
 
         # Get server URL from environment or use default
         server_url = os.getenv("OPENHANDS_CLOUD_URL", "https://app.all-hands.dev")
@@ -323,7 +335,9 @@ class ConversationManager(Container):
         self._api_client = OpenHandsApiClient(server_url, api_key)
 
         # Initialize BTW interceptor with the api_client
-        conversation_id = str(self._state.conversation_id) if self._state.conversation_id else None
+        conversation_id = (
+            str(self._state.conversation_id) if self._state.conversation_id else None
+        )
 
         async def ask_agent_callback(conv_id: str, question: str) -> dict:
             """Callback to call the ask_agent API."""

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -47,6 +47,8 @@ from openhands_cli.tui.messages import (
 
 
 if TYPE_CHECKING:
+    from openhands_cli.auth.api_client import OpenHandsApiClient
+    from openhands_cli.tui.core.btw_store import BtwStore
     from openhands_cli.tui.core.conversation_runner import ConversationRunner
     from openhands_cli.tui.core.state import ConversationContainer
 
@@ -183,14 +185,14 @@ class ConversationManager(Container):
         # Initialize BTW interceptor for side-channel questions
         # Note: api_client will be lazily initialized on first /btw use
         self._btw_interceptor: BtwInterceptor | None = None
-        self._api_client = None
+        self._api_client: OpenHandsApiClient | None = None
 
     def set_api_client(self, api_client, server_url: str | None = None) -> None:  # noqa: ARG002
         """Set the API client for BTW functionality.
 
         Args:
             api_client: The API client instance for making requests.
-            server_url: Optional server URL for the API (unused, kept for API compatibility).
+            server_url: Optional server URL (unused, kept for API compatibility).
         """
         self._api_client = api_client
 
@@ -255,9 +257,11 @@ class ConversationManager(Container):
             result = self._btw_interceptor.process(event.content)
 
             if result.is_btw and result.entry_id:
-                # Handle BTW command - call the API asynchronously
-                self._handle_btw_message(
-                    event.content, result.question, result.entry_id
+                # Handle BTW command - run asynchronously without blocking
+                self.run_worker(
+                    self._handle_btw_message(
+                        event.content, result.question, result.entry_id
+                    )
                 )
                 return  # Don't process as regular message
 
@@ -298,6 +302,7 @@ class ConversationManager(Container):
             if self._api_client is None:
                 self._init_api_client()
 
+            assert self._api_client is not None
             response = await self._api_client.ask_agent(conversation_id, question)
             await self._btw_interceptor.resolve(entry_id, response.get("response", ""))
 
@@ -341,6 +346,7 @@ class ConversationManager(Container):
 
         async def ask_agent_callback(conv_id: str, question: str) -> dict:
             """Callback to call the ask_agent API."""
+            assert self._api_client is not None
             return await self._api_client.ask_agent(conv_id, question)
 
         self._btw_interceptor = BtwInterceptor(

--- a/tests/acp/test_slash_commands.py
+++ b/tests/acp/test_slash_commands.py
@@ -78,11 +78,11 @@ class TestSlashCommandFunctions:
     def test_get_available_commands(self):
         """Test getting available slash commands."""
         commands = get_available_slash_commands()
-        assert len(commands) == 2
+        assert len(commands) == 3
 
-        # Check that both commands are present (without "/" prefix per ACP spec)
+        # Check that all commands are present (without "/" prefix per ACP spec)
         command_names = {cmd.name for cmd in commands}
-        assert command_names == {"help", "confirm"}
+        assert command_names == {"help", "confirm", "btw"}
 
         # Check that descriptions exist
         help_cmd = next(cmd for cmd in commands if cmd.name == "help")


### PR DESCRIPTION
## Summary

Implements the `/btw` side-channel command feature from OpenHands frontend [PR #13918](https://github.com/OpenHands/OpenHands/pull/13918) in the OpenHands CLI.

### Changes

- **BTW Store** (`openhands_cli/tui/core/btw_store.py`): A simple in-memory store for tracking side-channel questions (pending, resolved, failed) per conversation.

- **BTW Interceptor** (`openhands_cli/tui/core/btw_interceptor.py`): Intercepts `/btw` commands and routes them through the ask_agent side-channel without disrupting the main task flow.

- **API Client** (`openhands_cli/auth/api_client.py`): Added `ask_agent` method to call the `/api/conversations/{id}/ask_agent` endpoint.

- **Conversation Manager** (`openhands_cli/tui/core/conversation_manager.py`): Integrated BTW interceptor to handle `/btw` commands in the TUI.

- **Slash Commands** (`openhands_cli/acp_impl/slash_commands.py`): Added `/btw` to the list of available slash commands.

### How to Test

- Authenticate with OpenHands Cloud (`openhands login`)
- Start a conversation in the CLI
- Send `/btw <question>` to ask a side question without derailing the main task
- The agent should respond via a notification without interrupting the main task

### Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Related

- Frontend PR: https://github.com/OpenHands/OpenHands/pull/13918

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/373d9ac4-757a-4b2e-81a4-a490bfc7771c)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/btw-side-channel
```