### PR TITLE
fix: emit valid JSONL from --json flag instead of pretty-printed blocks

### DIFF
--- a/openhands_cli/utils.py
+++ b/openhands_cli/utils.py
@@ -263,7 +263,4 @@ def json_callback(event: Event) -> None:
     if isinstance(event, SystemPromptEvent):
         return
 
-    data = event.model_dump()
-    pretty_json = json.dumps(data, indent=2, sort_keys=True)
-    print("--JSON Event--")
-    print(pretty_json)
+    print(json.dumps(event.model_dump()))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,12 +194,10 @@ class TestJsonCallback:
         with patch("builtins.print") as mock_print:
             json_callback(message_event)
 
-            # Should have two print calls: header and JSON
-            assert mock_print.call_count == 2
-            mock_print.assert_any_call("--JSON Event--")
-
-            # Verify valid JSON output
-            json_output = mock_print.call_args_list[1][0][0]
+            # Should have exactly one print call with a single-line JSON string
+            assert mock_print.call_count == 1
+            json_output = mock_print.call_args_list[0][0][0]
+            assert "\n" not in json_output
             parsed_json = json.loads(json_output)
             assert isinstance(parsed_json, dict)
 
@@ -215,12 +213,10 @@ class TestJsonCallback:
         with patch("builtins.print") as mock_print:
             json_callback(event)
 
-            # Verify the output structure
-            assert mock_print.call_count == 2
-            mock_print.assert_any_call("--JSON Event--")
-
-            # Get and validate the JSON output
-            json_output = mock_print.call_args_list[1][0][0]
+            # Should have exactly one print call with a single-line JSON string
+            assert mock_print.call_count == 1
+            json_output = mock_print.call_args_list[0][0][0]
+            assert "\n" not in json_output
             parsed_json = json.loads(json_output)
 
             # Verify essential fields are present


### PR DESCRIPTION
## Summary

Fixes #676.

`--json` is documented as "Streams JSONL event outputs to terminal" but `json_callback` in `openhands_cli/utils.py` was emitting pretty-printed JSON blocks delimited by `--JSON Event--` markers — not valid JSONL.

This forces any parent process driving OpenHands as a subprocess to implement a custom stateful parser (detect markers, accumulate multi-line blocks, strip delimiters) instead of a simple `readline()` loop:

```python
# What the contract promises — impossible with the old format
for line in process.stdout:
    event = json.loads(line)
```

## Changes

**`openhands_cli/utils.py`**

```python
# Before
def json_callback(event: Event) -> None:
    if isinstance(event, SystemPromptEvent):
        return
    data = event.model_dump()
    pretty_json = json.dumps(data, indent=2, sort_keys=True)
    print("--JSON Event--")
    print(pretty_json)

# After
def json_callback(event: Event) -> None:
    if isinstance(event, SystemPromptEvent):
        return
    print(json.dumps(event.model_dump()))
```

**`tests/test_utils.py`** — updated `TestJsonCallback` tests to assert a single `print` call per event, valid single-line JSON (no embedded newlines), and removed assertions for the `--JSON Event--` header.

## Notes

- Pretty-printed output for human debugging belongs on stderr, not stdout. stdout is for machine consumption when `--json` is active.
- This is a breaking change for any consumer currently parsing the `--JSON Event--` format, but since that format was never the documented contract, this is a bug fix.
