### PR TITLE
tui: move startup warmup off the critical path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,11 @@ To view the generated SVG snapshots in a browser:
 - Commit SVG snapshots.
 - Review snapshot diffs carefully.
 
+### Startup UX note
+- Keep the initial TUI render non-blocking: splash/UI should appear before version checks, MCP/resource discovery, or conversation runner warmup finish.
+- `ConversationRunner` now supports lazy initialization; direct construction stays eager by default for compatibility/tests, while `RunnerFactory` opts into `initialize=False` so app startup can prewarm in the background.
+- If startup/warmup data arrives later (version info, critic/resources), prefer updating reactive splash/status state instead of rebuilding the initial UI.
+
 
 ## Commit & Pull Request Guidelines
 - Follow the repo’s pattern: `<scope>: <concise message> (#NNN)` (see `git log`), where scope is the touched area (e.g., `auth`, `tui`, `fix`).

--- a/openhands_cli/tui/content/splash.py
+++ b/openhands_cli/tui/content/splash.py
@@ -2,7 +2,8 @@
 
 from textual.theme import Theme
 
-from openhands_cli.version_check import check_for_updates
+from openhands_cli import __version__
+from openhands_cli.version_check import VersionInfo
 
 
 def get_conversation_text(conversation_id: str, *, theme: Theme) -> str:
@@ -20,7 +21,6 @@ def get_conversation_text(conversation_id: str, *, theme: Theme) -> str:
 
 def get_openhands_banner() -> str:
     """Get the OpenHands ASCII art banner."""
-    # ASCII art with consistent line lengths for proper alignment
     banner_lines = [
         r"     ___                    _   _                 _     ",
         r"    /  _ \ _ __   ___ _ __ | | | | __ _ _ __   __| |___",
@@ -29,14 +29,53 @@ def get_openhands_banner() -> str:
         r"    \___ /| .__/ \___|_| |_|_| |_|\__,_|_| |_|\__,_|___/",
         r"          |_|                                           ",
     ]
-
-    # Find the maximum line length
     max_length = max(len(line) for line in banner_lines)
-
-    # Pad all lines to the same length for consistent alignment
     padded_lines = [line.ljust(max_length) for line in banner_lines]
-
     return "\n".join(padded_lines)
+
+
+def get_version_text(version_info: VersionInfo | None = None) -> str:
+    """Get the splash version text.
+
+    Args:
+        version_info: Optional version information from a background update check.
+    """
+    current_version = version_info.current_version if version_info else __version__
+    return f"OpenHands CLI v{current_version}"
+
+
+def get_update_notice(
+    *, theme: Theme, version_info: VersionInfo | None = None
+) -> str | None:
+    """Get the update notice text for the splash screen."""
+    if (
+        not version_info
+        or not version_info.needs_update
+        or not version_info.latest_version
+    ):
+        return None
+
+    return (
+        f"[{theme.primary}]⚠ Update available: {version_info.latest_version}[/]\n"
+        "Run 'uv tool upgrade openhands' to update"
+    )
+
+
+def get_critic_notice(*, theme: Theme, has_critic: bool) -> str | None:
+    """Get the critic notice text for the splash screen."""
+    if not has_critic:
+        return None
+
+    title = (
+        f"\n[{theme.primary}]Experimental Feature: Critic + "
+        "Iterative Refinement Mode[/]\n"
+    )
+    details = (
+        "[dim]Using OpenHands provider enables a free critic to predict task success. "
+        "Enable Iterative Refinement in settings to auto-prompt the agent when work "
+        "appears incomplete. Anonymized data collected. Disable in settings.[/dim]"
+    )
+    return title + details
 
 
 def get_splash_content(
@@ -44,6 +83,7 @@ def get_splash_content(
     *,
     theme: Theme,
     has_critic: bool = False,
+    version_info: VersionInfo | None = None,
 ) -> dict:
     """Get structured splash screen content for native Textual widgets.
 
@@ -51,22 +91,16 @@ def get_splash_content(
         conversation_id: Optional conversation ID to display
         theme: Theme to use for colors
         has_critic: Whether the agent has a critic configured
+        version_info: Optional version information from a background update check
     """
-    # Use theme colors
     primary_color = theme.primary
-
-    # Use Rich markup for colored banner (apply color to each line)
     banner_lines = get_openhands_banner().split("\n")
     colored_banner_lines = [f"[{primary_color}]{line}[/]" for line in banner_lines]
     banner = "\n".join(colored_banner_lines)
 
-    # Get version information
-    version_info = check_for_updates()
-
-    # Create structured content as dictionary
-    content = {
+    return {
         "banner": banner,
-        "version": f"OpenHands CLI v{version_info.current_version}",
+        "version": get_version_text(version_info),
         "status_text": "All set up!",
         "conversation_text": get_conversation_text(conversation_id, theme=theme),
         "conversation_id": conversation_id,
@@ -79,26 +113,6 @@ def get_splash_content(
                 "or / to scroll through available commands"
             ),
         ],
-        "update_notice": None,
-        "critic_notice": None,
+        "update_notice": get_update_notice(theme=theme, version_info=version_info),
+        "critic_notice": get_critic_notice(theme=theme, has_critic=has_critic),
     }
-
-    # Add update notification if needed
-    if version_info.needs_update and version_info.latest_version:
-        content["update_notice"] = (
-            f"[{primary_color}]⚠ Update available: {version_info.latest_version}[/]\n"
-            "Run 'uv tool upgrade openhands' to update"
-        )
-
-    # Add critic notification if enabled
-    if has_critic:
-        content["critic_notice"] = (
-            f"\n[{primary_color}]Experimental Feature: "
-            "Critic + Iterative Refinement Mode[/]\n"
-            "[dim]Using OpenHands provider enables a free critic to predict task "
-            "success. Enable Iterative Refinement in settings to auto-prompt the "
-            "agent when work appears incomplete. "
-            "Anonymized data collected. Disable in settings.[/dim]"
-        )
-
-    return content

--- a/openhands_cli/tui/core/conversation_crud_controller.py
+++ b/openhands_cli/tui/core/conversation_crud_controller.py
@@ -45,6 +45,7 @@ class ConversationCrudController:
         # Reset state - triggers reactive UI updates
         self._state.reset_conversation_state()
         self._state.conversation_id = UUID(new_id)
+        self._runners.start_prewarm(UUID(new_id))
 
         self._notify(
             "Started a new conversation",

--- a/openhands_cli/tui/core/conversation_manager.py
+++ b/openhands_cli/tui/core/conversation_manager.py
@@ -30,7 +30,12 @@ from openhands_cli.tui.core.conversation_crud_controller import (
 from openhands_cli.tui.core.conversation_switch_controller import (
     ConversationSwitchController,
 )
-from openhands_cli.tui.core.events import ConfirmationDecision, ShowConfirmationPanel
+from openhands_cli.tui.core.events import (
+    ConfirmationDecision,
+    ConversationWarmupCompleted,
+    ConversationWarmupFailed,
+    ShowConfirmationPanel,
+)
 from openhands_cli.tui.core.refinement_controller import RefinementController
 from openhands_cli.tui.core.runner_factory import RunnerFactory
 from openhands_cli.tui.core.runner_registry import RunnerRegistry
@@ -136,6 +141,8 @@ class ConversationManager(Container):
             state=self._state,
             message_pump=self,
             notification_callback=notification_callback,
+            run_worker=self.run_worker,
+            call_from_thread=lambda func, *args: self.app.call_from_thread(func, *args),
         )
 
         self._policy_service = ConfirmationPolicyService(
@@ -183,6 +190,13 @@ class ConversationManager(Container):
         """Get the conversation state."""
         return self._state
 
+    def start_prewarm(self, conversation_id: uuid.UUID | None = None) -> None:
+        """Start warming a conversation runner in the background."""
+        target_id = conversation_id or self._state.conversation_id
+        if target_id is None:
+            return
+        self._runners.start_prewarm(target_id)
+
     @property
     def current_runner(self) -> "ConversationRunner | None":
         """Get the current conversation runner."""
@@ -211,6 +225,37 @@ class ConversationManager(Container):
         """
         event.stop()
         await self._message_controller.handle_refinement_message(event.content)
+
+    @on(ConversationWarmupCompleted)
+    async def _on_conversation_warmup_completed(
+        self, event: ConversationWarmupCompleted
+    ) -> None:
+        """Update reactive startup state and flush queued messages."""
+        if event.conversation_id != self._state.conversation_id:
+            return
+
+        self._state.set_startup_status(None)
+        self._state.set_has_critic(event.has_critic)
+        self._state.set_loaded_resources(event.loaded_resources)
+
+        runner = self._runners.get_or_create(event.conversation_id)
+        if runner.conversation is not None:
+            self._state.attach_conversation_state(runner.conversation.state)
+
+        await self._message_controller.flush_pending_messages(event.conversation_id)
+
+    @on(ConversationWarmupFailed)
+    def _on_conversation_warmup_failed(self, event: ConversationWarmupFailed) -> None:
+        """Surface background warmup errors without blocking the UI."""
+        if event.conversation_id != self._state.conversation_id:
+            return
+
+        self._state.set_startup_status(None)
+        self.notify(
+            event.error,
+            title="Conversation Startup Error",
+            severity="error",
+        )
 
     @on(CriticResultReceived)
     def _on_critic_result_received(self, event: CriticResultReceived) -> None:

--- a/openhands_cli/tui/core/conversation_runner.py
+++ b/openhands_cli/tui/core/conversation_runner.py
@@ -1,6 +1,7 @@
 """Conversation runner with confirmation mode support."""
 
 import asyncio
+import threading
 import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -54,6 +55,7 @@ class ConversationRunner:
         *,
         env_overrides_enabled: bool = False,
         critic_disabled: bool = False,
+        initialize: bool = True,
     ) -> None:
         """Initialize the conversation runner.
 
@@ -69,17 +71,14 @@ class ConversationRunner:
             critic_disabled: If True, critic functionality will be disabled.
         """
         self.visualizer = visualizer
+        self._conversation_id = conversation_id
+        self._event_callback = event_callback
+        self._env_overrides_enabled = env_overrides_enabled
+        self._critic_disabled = critic_disabled
 
-        # Create conversation with policy from state
-        self.conversation: BaseConversation = setup_conversation(
-            conversation_id,
-            confirmation_policy=state.confirmation_policy,
-            visualizer=visualizer,
-            event_callback=event_callback,
-            env_overrides_enabled=env_overrides_enabled,
-            critic_disabled=critic_disabled,
-        )
-
+        self.conversation: BaseConversation | None = None
+        self._initialization_lock = threading.Lock()
+        self._warming_up = False
         self._running = False
 
         # State for reading (is_confirmation_active) and updating (set_running)
@@ -88,52 +87,106 @@ class ConversationRunner:
         self._message_pump = message_pump
         self._notification_callback = notification_callback
 
+        if initialize:
+            self.ensure_initialized()
+
     @property
     def is_confirmation_mode_active(self) -> bool:
         return self._state.is_confirmation_active
 
+    @property
+    def is_ready(self) -> bool:
+        """Check whether the conversation has been initialized."""
+        return self.conversation is not None
+
+    @property
+    def is_warming_up(self) -> bool:
+        """Check whether background conversation warmup is in progress."""
+        return self._warming_up
+
+    def ensure_initialized(self) -> BaseConversation | None:
+        """Initialize the conversation on demand.
+
+        This is safe to call from multiple threads; only one initialization will run.
+        """
+        if self.conversation is not None:
+            return self.conversation
+
+        with self._initialization_lock:
+            if self.conversation is not None:
+                return self.conversation
+
+            self._warming_up = True
+            try:
+                self.conversation = setup_conversation(
+                    self._conversation_id,
+                    confirmation_policy=self._state.confirmation_policy,
+                    visualizer=self.visualizer,
+                    event_callback=self._event_callback,
+                    env_overrides_enabled=self._env_overrides_enabled,
+                    critic_disabled=self._critic_disabled,
+                )
+            finally:
+                self._warming_up = False
+
+        return self.conversation
+
     async def queue_message(self, user_input: str) -> None:
-        """Queue a message for a running conversation"""
-        assert self.conversation is not None, "Conversation should be running"
+        """Queue a message for a running conversation."""
         assert user_input
+        conversation = self.ensure_initialized()
+        assert conversation is not None
         message = Message(
             role="user",
             content=[TextContent(text=user_input)],
         )
 
-        # This doesn't block - it just adds the message to the queue
-        # The running conversation will process it when ready
         loop = asyncio.get_running_loop()
-        # Run send_message in the same thread pool, not on the UI loop
-        await loop.run_in_executor(None, self.conversation.send_message, message)
+        await loop.run_in_executor(None, conversation.send_message, message)
 
     async def process_message_async(
         self, user_input: str, headless: bool = False
     ) -> None:
-        """Process a user message asynchronously to keep UI unblocked.
-
-        Args:
-            user_input: The user's message text
-        """
-        # Create message from user input
-        message = Message(
-            role="user",
-            content=[TextContent(text=user_input)],
-        )
-
-        # Run conversation processing in a separate thread to avoid blocking UI
+        """Process a single user message asynchronously to keep UI unblocked."""
         await asyncio.get_event_loop().run_in_executor(
-            None, self._run_conversation_sync, message, headless
+            None, self._run_conversation_batch_sync, [user_input], headless
         )
+
+    async def process_pending_messages_async(
+        self, user_inputs: list[str], headless: bool = False
+    ) -> None:
+        """Process multiple pre-rendered messages after background warmup completes."""
+        if not user_inputs:
+            return
+
+        await asyncio.get_event_loop().run_in_executor(
+            None, self._run_conversation_batch_sync, user_inputs, headless
+        )
+
+    def _run_conversation_batch_sync(
+        self, user_inputs: list[str], headless: bool = False
+    ) -> None:
+        """Run one or more messages synchronously in a worker thread."""
+        conversation = self.ensure_initialized()
+        if conversation is None:
+            return
+
+        for user_input in user_inputs:
+            message = Message(
+                role="user",
+                content=[TextContent(text=user_input)],
+            )
+            conversation.send_message(message)
+
+        self._execute_conversation(headless=headless)
 
     def _run_conversation_sync(self, message: Message, headless: bool = False) -> None:
-        """Run the conversation synchronously in a thread.
+        """Compatibility wrapper for tests and existing sync call sites."""
+        conversation = self.ensure_initialized()
+        if conversation is None:
+            return
 
-        Args:
-            message: The message to process
-            headless: If True, print status to console
-        """
-        self.conversation.send_message(message)
+        conversation.send_message(message)
         self._execute_conversation(headless=headless)
 
     def _execute_conversation(
@@ -192,8 +245,12 @@ class ConversationRunner:
 
     def _request_confirmation(self) -> None:
         """Post ShowConfirmationPanel message for pending actions."""
+        conversation = self.conversation
+        if conversation is None:
+            return
+
         pending_actions = SDKConversationState.get_unmatched_actions(
-            self.conversation.state.events
+            conversation.state.events
         )
         if pending_actions:
             self._message_pump.post_message(ShowConfirmationPanel(pending_actions))
@@ -212,12 +269,16 @@ class ConversationRunner:
     async def pause(self) -> None:
         """Pause the running conversation."""
         if self._running:
+            conversation = self.conversation
+            if conversation is None:
+                return
+
             self._notification_callback(
                 "Pausing conversation",
                 "Pausing conversation, this make take a few seconds...",
                 "information",
             )
-            await asyncio.to_thread(self.conversation.pause)
+            await asyncio.to_thread(conversation.pause)
         else:
             self._notification_callback(
                 "No running conversation", "No running conversation to pause", "warning"
@@ -234,6 +295,10 @@ class ConversationRunner:
             return
 
         try:
+            conversation = self.ensure_initialized()
+            if conversation is None:
+                return
+
             # Notify user that condensation is starting
             self._notification_callback(
                 "Condensation Started",
@@ -242,7 +307,7 @@ class ConversationRunner:
             )
 
             # Run condensation in a separate thread to avoid blocking UI
-            await asyncio.to_thread(self.conversation.condense)
+            await asyncio.to_thread(conversation.condense)
 
             # Notify user of successful completion
             self._notification_callback(

--- a/openhands_cli/tui/core/conversation_switch_controller.py
+++ b/openhands_cli/tui/core/conversation_switch_controller.py
@@ -67,7 +67,9 @@ class ConversationSwitchController:
                 try:
                     runner = self._runners.current
                     if runner is not None and runner.is_running:
-                        runner.conversation.pause()
+                        conversation = runner.conversation
+                        if conversation is not None:
+                            conversation.pause()
                 except Exception as exc:  # pragma: no cover - UI error handling
                     self._call_from_thread(self._handle_switch_error, exc, previous_id)
                     return
@@ -110,6 +112,7 @@ class ConversationSwitchController:
 
         self._runners.clear_current()
         self._runners.get_or_create(target_id)
+        self._runners.start_prewarm(target_id)
 
         self._state.finish_switching(target_id)
         self._state.set_switch_confirmation_target(None)

--- a/openhands_cli/tui/core/events.py
+++ b/openhands_cli/tui/core/events.py
@@ -22,6 +22,7 @@ from openhands_cli.user_actions.types import UserConfirmation
 
 if TYPE_CHECKING:
     from openhands.sdk.event import ActionEvent
+    from openhands_cli.tui.content.resources import LoadedResourcesInfo
 
 
 class RequestSwitchConfirmation(Message):
@@ -65,3 +66,27 @@ class ConfirmationDecision(Message):
     def __init__(self, decision: UserConfirmation) -> None:
         super().__init__()
         self.decision = decision
+
+
+class ConversationWarmupCompleted(Message):
+    """Background conversation warmup completed for a conversation."""
+
+    def __init__(
+        self,
+        conversation_id: uuid.UUID,
+        has_critic: bool,
+        loaded_resources: "LoadedResourcesInfo",
+    ) -> None:
+        super().__init__()
+        self.conversation_id = conversation_id
+        self.has_critic = has_critic
+        self.loaded_resources = loaded_resources
+
+
+class ConversationWarmupFailed(Message):
+    """Background conversation warmup failed for a conversation."""
+
+    def __init__(self, conversation_id: uuid.UUID, error: str) -> None:
+        super().__init__()
+        self.conversation_id = conversation_id
+        self.error = error

--- a/openhands_cli/tui/core/runner_factory.py
+++ b/openhands_cli/tui/core/runner_factory.py
@@ -81,8 +81,7 @@ class RunnerFactory:
             event_callback=event_callback,
             env_overrides_enabled=self._env_overrides_enabled,
             critic_disabled=self._critic_disabled,
+            initialize=False,
         )
 
-        # Attach conversation to state for metrics reading
-        self._state.attach_conversation_state(runner.conversation.state)
         return runner

--- a/openhands_cli/tui/core/runner_registry.py
+++ b/openhands_cli/tui/core/runner_registry.py
@@ -1,11 +1,20 @@
-"""RunnerRegistry - owns ConversationRunner instances and current runner."""
+"""RunnerRegistry - owns ConversationRunner instances and background warmup."""
 
 from __future__ import annotations
 
+import threading
 import uuid
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from textual.message_pump import MessagePump
+
+from openhands_cli.locations import get_work_dir
+from openhands_cli.tui.content.resources import collect_loaded_resources
+from openhands_cli.tui.core.events import (
+    ConversationWarmupCompleted,
+    ConversationWarmupFailed,
+)
 
 
 if TYPE_CHECKING:
@@ -25,13 +34,19 @@ class RunnerRegistry:
         state: ConversationContainer,
         message_pump: MessagePump,
         notification_callback: NotificationCallback,
+        run_worker: Callable[..., object],
+        call_from_thread: Callable[..., None],
     ) -> None:
         self._factory = factory
         self._state = state
         self._message_pump = message_pump
         self._notification_callback = notification_callback
+        self._run_worker = run_worker
+        self._call_from_thread = call_from_thread
         self._runners: dict[uuid.UUID, ConversationRunner] = {}
         self._current_runner: ConversationRunner | None = None
+        self._warming_conversations: set[uuid.UUID] = set()
+        self._pending_messages: dict[uuid.UUID, list[str]] = {}
 
     @property
     def current(self) -> ConversationRunner | None:
@@ -55,3 +70,84 @@ class RunnerRegistry:
 
         self._current_runner = runner
         return runner
+
+    def is_warming(self, conversation_id: uuid.UUID) -> bool:
+        return conversation_id in self._warming_conversations
+
+    def enqueue_pending_message(self, conversation_id: uuid.UUID, content: str) -> None:
+        self._pending_messages.setdefault(conversation_id, []).append(content)
+
+    def pop_pending_messages(self, conversation_id: uuid.UUID) -> list[str]:
+        return self._pending_messages.pop(conversation_id, [])
+
+    def start_prewarm(self, conversation_id: uuid.UUID) -> None:
+        runner = self.get_or_create(conversation_id)
+        if runner.is_ready:
+            self._post_warmup_completed(conversation_id, runner)
+            return
+
+        if conversation_id in self._warming_conversations:
+            return
+
+        self._warming_conversations.add(conversation_id)
+        self._state.set_startup_status(
+            "Preparing conversation tools in the background…"
+        )
+
+        def worker() -> None:
+            try:
+                runner.ensure_initialized()
+            except Exception as exc:
+                error_message = f"{type(exc).__name__}: {exc}"
+                self._dispatch_to_main_thread(
+                    self._handle_warmup_failure, conversation_id, error_message
+                )
+                return
+
+            self._dispatch_to_main_thread(
+                self._post_warmup_completed, conversation_id, runner
+            )
+
+        self._run_worker(
+            worker,
+            name=f"warmup_{conversation_id.hex[:8]}",
+            group=f"warmup_{conversation_id}",
+            exclusive=True,
+            thread=True,
+            exit_on_error=False,
+        )
+
+    def _dispatch_to_main_thread(
+        self, callback: Callable[..., None], *args: object
+    ) -> None:
+        if threading.current_thread() is threading.main_thread():
+            callback(*args)
+        else:
+            self._call_from_thread(callback, *args)
+
+    def _post_warmup_completed(
+        self, conversation_id: uuid.UUID, runner: ConversationRunner
+    ) -> None:
+        self._warming_conversations.discard(conversation_id)
+        if runner.conversation is None:
+            return
+
+        agent = getattr(runner.conversation, "agent", None)
+        loaded_resources = collect_loaded_resources(
+            agent=agent,
+            working_dir=get_work_dir(),
+        )
+        has_critic = bool(getattr(agent, "critic", None))
+        self._message_pump.post_message(
+            ConversationWarmupCompleted(
+                conversation_id=conversation_id,
+                has_critic=has_critic,
+                loaded_resources=loaded_resources,
+            )
+        )
+
+    def _handle_warmup_failure(self, conversation_id: uuid.UUID, error: str) -> None:
+        self._warming_conversations.discard(conversation_id)
+        self._message_pump.post_message(
+            ConversationWarmupFailed(conversation_id=conversation_id, error=error)
+        )

--- a/openhands_cli/tui/core/state.py
+++ b/openhands_cli/tui/core/state.py
@@ -42,6 +42,8 @@ from openhands.sdk.security.confirmation_policy import (
 )
 from openhands_cli.shared import extract_conversation_summary
 from openhands_cli.stores import CriticSettings
+from openhands_cli.tui.content.resources import LoadedResourcesInfo
+from openhands_cli.version_check import VersionInfo
 
 
 if TYPE_CHECKING:
@@ -49,7 +51,6 @@ if TYPE_CHECKING:
 
     from openhands.sdk.conversation.base import ConversationStateProtocol
     from openhands.sdk.event import ActionEvent
-    from openhands_cli.tui.content.resources import LoadedResourcesInfo
     from openhands_cli.tui.widgets.input_area import InputAreaContainer
     from openhands_cli.tui.widgets.main_display import ScrollableContent
 
@@ -125,9 +126,20 @@ class ConversationContainer(Container):
     metrics: var[Metrics | None] = var(None)
     """Combined metrics from conversation stats."""
 
+    # ---- Startup Status ----
+    startup_status: var[str | None] = var(None)
+    """Transient status shown while preparing a conversation in the background."""
+
+    # ---- Version / Splash State ----
+    version_info: var[VersionInfo | None] = var(None)
+    """Version information for the splash screen, populated asynchronously."""
+
     # ---- Loaded Resources ----
-    loaded_resources: var["LoadedResourcesInfo | None"] = var(None)
+    loaded_resources: var[LoadedResourcesInfo] = var(LoadedResourcesInfo())
     """Loaded skills, hooks, and MCPs for the current conversation."""
+
+    has_critic: var[bool] = var(False)
+    """Whether the current conversation's agent has a critic configured."""
 
     # ---- Critic Settings ----
     critic_settings: var[CriticSettings] = var(CriticSettings())
@@ -189,6 +201,8 @@ class ConversationContainer(Container):
             yield SplashContent(id="splash_content").data_bind(
                 conversation_id=ConversationContainer.conversation_id,
                 loaded_resources=ConversationContainer.loaded_resources,
+                version_info=ConversationContainer.version_info,
+                has_critic=ConversationContainer.has_critic,
             )
 
         # Input area docked to bottom
@@ -199,6 +213,7 @@ class ConversationContainer(Container):
                 running=ConversationContainer.running,
                 elapsed_seconds=ConversationContainer.elapsed_seconds,
                 critic_settings=ConversationContainer.critic_settings,
+                startup_status=ConversationContainer.startup_status,
             )
             yield InputField(
                 placeholder="Type your message, @mention a file, or / for commands"
@@ -369,9 +384,21 @@ class ConversationContainer(Container):
         """Set pending switch confirmation target. Thread-safe."""
         self._schedule_update("switch_confirmation_target", target_id)
 
-    def set_loaded_resources(self, resources: "LoadedResourcesInfo") -> None:
+    def set_startup_status(self, status: str | None) -> None:
+        """Set the transient startup status message. Thread-safe."""
+        self._schedule_update("startup_status", status)
+
+    def set_version_info(self, version_info: VersionInfo | None) -> None:
+        """Set asynchronously loaded version information. Thread-safe."""
+        self._schedule_update("version_info", version_info)
+
+    def set_loaded_resources(self, resources: LoadedResourcesInfo) -> None:
         """Set loaded resources (skills, hooks, MCPs). Thread-safe."""
         self._schedule_update("loaded_resources", resources)
+
+    def set_has_critic(self, value: bool) -> None:
+        """Set whether the current conversation has a critic configured."""
+        self._schedule_update("has_critic", value)
 
     def set_critic_settings(self, settings: CriticSettings) -> None:
         """Set critic settings for iterative refinement. Thread-safe."""
@@ -423,8 +450,11 @@ class ConversationContainer(Container):
         self.running = False
         self.elapsed_seconds = 0
         self.metrics = None
+        self.startup_status = None
         self.conversation_title = None
         self.pending_action_count = 0
+        self.loaded_resources = LoadedResourcesInfo()
+        self.has_critic = False
         self.refinement_iteration = 0
         self.switch_confirmation_target = None
         self._conversation_start_time = None

--- a/openhands_cli/tui/core/user_message_controller.py
+++ b/openhands_cli/tui/core/user_message_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 
 
@@ -75,18 +76,35 @@ class UserMessageController:
         await self._process_message(runner, content)
 
     async def _process_message(self, runner: ConversationRunner, content: str) -> None:
-        """Process a message by queuing or starting a new run.
-
-        Args:
-            runner: The conversation runner to use.
-            content: The message content to process.
-        """
+        """Process a message by queuing, warming up, or starting a run."""
+        if self._state.conversation_id is None:
+            return
 
         if runner.is_running:
             await runner.queue_message(content)
             return
 
+        if runner.is_warming_up or not runner.is_ready:
+            self._runners.enqueue_pending_message(self._state.conversation_id, content)
+            self._runners.start_prewarm(self._state.conversation_id)
+            return
+
         self._run_worker(
             runner.process_message_async(content, self._headless_mode),
             name="process_message",
+        )
+
+    async def flush_pending_messages(self, conversation_id: uuid.UUID) -> None:
+        """Flush any pre-rendered messages once warmup completes."""
+        pending_messages = self._runners.pop_pending_messages(conversation_id)
+        if not pending_messages:
+            return
+
+        runner = self._runners.get_or_create(conversation_id)
+        self._run_worker(
+            runner.process_pending_messages_async(
+                pending_messages,
+                self._headless_mode,
+            ),
+            name="process_pending_messages",
         )

--- a/openhands_cli/tui/textual_app.py
+++ b/openhands_cli/tui/textual_app.py
@@ -57,14 +57,9 @@ from openhands.sdk.security.confirmation_policy import (
 )
 from openhands.sdk.security.risk import SecurityRisk
 from openhands_cli.conversations.store.local import LocalFileStore
-from openhands_cli.locations import get_conversations_dir, get_work_dir
-from openhands_cli.stores import (
-    AgentStore,
-    CliSettings,
-    MissingEnvironmentVariablesError,
-)
+from openhands_cli.locations import get_conversations_dir
+from openhands_cli.stores import CliSettings, MissingEnvironmentVariablesError
 from openhands_cli.theme import OPENHANDS_THEME
-from openhands_cli.tui.content.resources import collect_loaded_resources
 from openhands_cli.tui.core import (
     ConversationContainer,
     ConversationFinished,
@@ -87,6 +82,7 @@ from openhands_cli.tui.widgets.collapsible import (
     CollapsibleTitle,
 )
 from openhands_cli.tui.widgets.splash import SplashContent
+from openhands_cli.version_check import check_for_updates
 
 
 class OpenHandsApp(CollapsibleNavigationMixin, App):
@@ -413,51 +409,32 @@ class OpenHandsApp(CollapsibleNavigationMixin, App):
                 timeout=10.0,
             )
 
-    def _initialize_main_ui(self) -> None:
-        """Initialize the main UI components.
+    def _start_background_version_check(self) -> None:
+        """Load version information without blocking the initial UI render."""
 
-        This method is responsible for:
-        1. Checking if the agent has a critic configured
-        2. Collecting and displaying loaded resources (skills, hooks, MCPs)
-        3. Initializing the splash content (one-time setup)
-        4. Processing any queued inputs
+        def worker() -> None:
+            self.conversation_state.set_version_info(check_for_updates())
 
-        UI lifecycle is owned by OpenHandsApp, not ConversationContainer. The splash
-        content initialization is a direct method call, not a reactive
-        state change, because it's a one-time operation.
-        """
-
-        splash_content = self.query_one("#splash_content", SplashContent)
-
-        # Check if agent has critic configured and collect resources
-        has_critic = False
-        agent = None
-        try:
-            agent_store = AgentStore()
-            agent = agent_store.load_or_create(
-                env_overrides_enabled=self.env_overrides_enabled,
-                critic_disabled=self.critic_disabled,
-            )
-            if agent:
-                has_critic = agent.critic is not None
-        except Exception:
-            # If we can't load agent, just continue without critic notice
-            pass
-
-        # Collect loaded resources info using the utility function
-        loaded_resources = collect_loaded_resources(
-            agent=agent,
-            working_dir=get_work_dir(),
+        self.run_worker(
+            worker,
+            name="version_check",
+            group="startup_version_check",
+            exclusive=True,
+            thread=True,
+            exit_on_error=False,
         )
 
-        # Initialize splash content (resources are handled reactively)
-        splash_content.initialize(has_critic=has_critic)
+    def _initialize_main_ui(self) -> None:
+        """Initialize the main UI components without blocking on startup work."""
+        splash_content = self.query_one("#splash_content", SplashContent)
+        splash_content.initialize()
 
-        # Set loaded resources on ConversationContainer - triggers reactive update
-        # in SplashContent via data_bind
-        self.conversation_state.set_loaded_resources(loaded_resources)
+        if self.conversation_state.conversation_id is not None:
+            self.conversation_manager.start_prewarm(
+                self.conversation_state.conversation_id
+            )
 
-        # Process any queued inputs
+        self._start_background_version_check()
         self._process_queued_inputs()
 
     def _process_queued_inputs(self) -> None:

--- a/openhands_cli/tui/widgets/splash.py
+++ b/openhands_cli/tui/widgets/splash.py
@@ -25,7 +25,6 @@ Example:
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
 from textual.containers import Container
@@ -33,11 +32,15 @@ from textual.reactive import var
 from textual.widgets import Static
 
 from openhands_cli.theme import OPENHANDS_THEME
-from openhands_cli.tui.content.splash import get_conversation_text, get_splash_content
-
-
-if TYPE_CHECKING:
-    from openhands_cli.tui.content.resources import LoadedResourcesInfo
+from openhands_cli.tui.content.resources import LoadedResourcesInfo
+from openhands_cli.tui.content.splash import (
+    get_conversation_text,
+    get_critic_notice,
+    get_splash_content,
+    get_update_notice,
+    get_version_text,
+)
+from openhands_cli.version_check import VersionInfo
 
 
 class SplashContent(Container):
@@ -68,12 +71,14 @@ class SplashContent(Container):
     conversation_id: var[uuid.UUID | None] = var(None)
 
     # Reactive property bound from ConversationContainer for loaded resources
-    # None indicates resources not yet loaded
-    loaded_resources: var[LoadedResourcesInfo | None] = var(None)
+    loaded_resources: var[LoadedResourcesInfo] = var(LoadedResourcesInfo())
+
+    # Reactive properties for asynchronously loaded splash metadata
+    version_info: var[VersionInfo | None] = var(None)
+    has_critic: var[bool] = var(False)
 
     # Internal state (not in ConversationContainer - widget owns its initialization)
     _is_initialized: bool = False
-    _has_critic: bool = False
 
     def __init__(self, **kwargs) -> None:
         """Initialize the splash content container."""
@@ -96,41 +101,57 @@ class SplashContent(Container):
         yield Static(id="splash_update_notice", classes="splash-update-notice")
         yield Static(id="splash_critic_notice", classes="splash-critic-notice")
 
-    def initialize(self, *, has_critic: bool = False) -> None:
+    def initialize(self) -> None:
         """Initialize and show the splash content.
 
         Called by OpenHandsApp during UI setup. This is a one-time
-        operation that populates all splash widgets and makes them visible.
-
-        Note: Loaded resources are handled reactively via data_bind to
-        loaded_resources. When ConversationContainer.loaded_resources is set,
-        watch_loaded_resources will automatically add the collapsible.
-
-        Args:
-            has_critic: Whether the agent has a critic configured.
+        operation that populates the static splash widgets immediately.
+        Asynchronous metadata such as version info, critic availability,
+        and loaded resources update reactively when background warmup
+        completes.
         """
         if self._is_initialized:
             return
 
-        self._has_critic = has_critic
         self._populate_content()
         self._is_initialized = True
 
     def watch_loaded_resources(
         self,
-        _old_value: LoadedResourcesInfo | None,
-        new_value: LoadedResourcesInfo | None,
+        _old_value: LoadedResourcesInfo,
+        new_value: LoadedResourcesInfo,
     ) -> None:
-        """Handle loaded_resources changes reactively.
-
-        When resources are set on ConversationContainer, this watcher
-        automatically adds or updates the loaded resources collapsible.
-        """
+        """Handle loaded_resources changes reactively."""
         if not self._is_initialized:
             return
 
-        if new_value and new_value.has_resources():
+        if new_value.has_resources():
             self._add_or_update_loaded_resources_collapsible(new_value)
+        else:
+            self._remove_loaded_resources_collapsible()
+
+    def watch_version_info(
+        self, _old_value: VersionInfo | None, new_value: VersionInfo | None
+    ) -> None:
+        """Update version text and update notice when background check completes."""
+        if not self._is_initialized:
+            return
+
+        self.query_one("#splash_version", Static).update(get_version_text(new_value))
+        self._update_notice_widget(
+            widget_id="#splash_update_notice",
+            content=get_update_notice(theme=OPENHANDS_THEME, version_info=new_value),
+        )
+
+    def watch_has_critic(self, _old_value: bool, new_value: bool) -> None:
+        """Update critic notice when background warmup completes."""
+        if not self._is_initialized:
+            return
+
+        self._update_notice_widget(
+            widget_id="#splash_critic_notice",
+            content=get_critic_notice(theme=OPENHANDS_THEME, has_critic=new_value),
+        )
 
     def _add_or_update_loaded_resources_collapsible(
         self, loaded_resources: LoadedResourcesInfo
@@ -158,6 +179,12 @@ class SplashContent(Container):
             )
             self.mount(collapsible)
 
+    def _remove_loaded_resources_collapsible(self) -> None:
+        """Remove the loaded resources collapsible when nothing is loaded."""
+        existing = self.query("#loaded_resources_collapsible")
+        if existing:
+            existing.first().remove()
+
     @property
     def is_initialized(self) -> bool:
         """Check if splash content has been initialized."""
@@ -180,15 +207,14 @@ class SplashContent(Container):
 
     def _populate_content(self) -> None:
         """Populate splash content widgets with actual content."""
-        # Use empty string if conversation_id is None (shouldn't happen during init)
         conv_id_hex = self.conversation_id.hex if self.conversation_id else ""
         splash_content = get_splash_content(
             conversation_id=conv_id_hex,
             theme=OPENHANDS_THEME,
-            has_critic=self._has_critic,
+            has_critic=self.has_critic,
+            version_info=self.version_info,
         )
 
-        # Update individual splash widgets
         self.query_one("#splash_banner", Static).update(splash_content["banner"])
         self.query_one("#splash_version", Static).update(splash_content["version"])
         self.query_one("#splash_status", Static).update(splash_content["status_text"])
@@ -199,22 +225,22 @@ class SplashContent(Container):
             splash_content["instructions_header"]
         )
 
-        # Join instructions into a single string
         instructions_text = "\n".join(splash_content["instructions"])
         self.query_one("#splash_instructions", Static).update(instructions_text)
+        self._update_notice_widget(
+            widget_id="#splash_update_notice",
+            content=splash_content["update_notice"],
+        )
+        self._update_notice_widget(
+            widget_id="#splash_critic_notice",
+            content=splash_content["critic_notice"],
+        )
 
-        # Update notice (show only if content exists)
-        update_notice_widget = self.query_one("#splash_update_notice", Static)
-        if splash_content["update_notice"]:
-            update_notice_widget.update(splash_content["update_notice"])
-            update_notice_widget.display = True
+    def _update_notice_widget(self, *, widget_id: str, content: str | None) -> None:
+        """Show or hide a conditional splash notice widget."""
+        notice_widget = self.query_one(widget_id, Static)
+        if content:
+            notice_widget.update(content)
+            notice_widget.display = True
         else:
-            update_notice_widget.display = False
-
-        # Update critic notice (show only if content exists)
-        critic_notice_widget = self.query_one("#splash_critic_notice", Static)
-        if splash_content["critic_notice"]:
-            critic_notice_widget.update(splash_content["critic_notice"])
-            critic_notice_widget.display = True
-        else:
-            critic_notice_widget.display = False
+            notice_widget.display = False

--- a/openhands_cli/tui/widgets/status_line.py
+++ b/openhands_cli/tui/widgets/status_line.py
@@ -33,6 +33,7 @@ class WorkingStatusLine(Static):
     running: var[bool] = var(False)
     elapsed_seconds: var[int] = var(0)
     critic_settings: var[CriticSettings] = var(CriticSettings())
+    startup_status: var[str | None] = var(None)
 
     def __init__(self, **kwargs) -> None:
         super().__init__("", id="working_status_line", markup=True, **kwargs)
@@ -59,6 +60,10 @@ class WorkingStatusLine(Static):
 
     def watch_critic_settings(self, _settings: CriticSettings) -> None:
         """React to critic settings changes from ConversationContainer."""
+        self._update_text()
+
+    def watch_startup_status(self, _status: str | None) -> None:
+        """React to startup preparation status changes."""
         self._update_text()
 
     # ----- Internal helpers -----
@@ -103,6 +108,8 @@ class WorkingStatusLine(Static):
         working_text = self._get_working_text()
         if working_text:
             parts.append(working_text)
+        elif self.startup_status:
+            parts.append(self.startup_status)
 
         # Join parts with separator
         if parts:

--- a/tests/tui/core/test_user_message_controller.py
+++ b/tests/tui/core/test_user_message_controller.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import uuid
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from openhands_cli.tui.core.user_message_controller import UserMessageController
+
+
+if TYPE_CHECKING:
+    from openhands_cli.tui.core.runner_registry import RunnerRegistry
 
 
 class _FakeRunner:
@@ -62,7 +67,7 @@ async def test_handle_user_message_queues_until_runner_is_ready() -> None:
     runners = _FakeRunners(runner)
     controller = UserMessageController(
         state=state,
-        runners=runners,
+        runners=cast("RunnerRegistry", runners),
         run_worker=run_worker,
         headless_mode=False,
     )
@@ -87,7 +92,7 @@ async def test_handle_user_message_starts_processing_when_runner_is_ready() -> N
     runners = _FakeRunners(runner)
     controller = UserMessageController(
         state=state,
-        runners=runners,
+        runners=cast("RunnerRegistry", runners),
         run_worker=run_worker,
         headless_mode=False,
     )
@@ -114,7 +119,7 @@ async def test_flush_pending_messages_starts_batch_processing() -> None:
     runners.pending_messages[conversation_id] = ["one", "two"]
     controller = UserMessageController(
         state=state,
-        runners=runners,
+        runners=cast("RunnerRegistry", runners),
         run_worker=run_worker,
         headless_mode=True,
     )

--- a/tests/tui/core/test_user_message_controller.py
+++ b/tests/tui/core/test_user_message_controller.py
@@ -1,0 +1,127 @@
+"""Tests for background startup handling in UserMessageController."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openhands_cli.tui.core.user_message_controller import UserMessageController
+
+
+class _FakeRunner:
+    def __init__(
+        self,
+        *,
+        is_running: bool = False,
+        is_warming_up: bool = False,
+        is_ready: bool = True,
+    ) -> None:
+        self.is_running = is_running
+        self.is_warming_up = is_warming_up
+        self.is_ready = is_ready
+        self.visualizer = MagicMock()
+        self.queue_message = AsyncMock()
+        self.process_message_job = object()
+        self.process_pending_job = object()
+        self.process_message_async = MagicMock(return_value=self.process_message_job)
+        self.process_pending_messages_async = MagicMock(
+            return_value=self.process_pending_job
+        )
+
+
+class _FakeRunners:
+    def __init__(self, runner: _FakeRunner) -> None:
+        self.runner = runner
+        self.enqueued: list[tuple[uuid.UUID, str]] = []
+        self.started: list[uuid.UUID] = []
+        self.pending_messages: dict[uuid.UUID, list[str]] = {}
+
+    def get_or_create(self, conversation_id: uuid.UUID) -> _FakeRunner:
+        return self.runner
+
+    def enqueue_pending_message(self, conversation_id: uuid.UUID, content: str) -> None:
+        self.enqueued.append((conversation_id, content))
+
+    def start_prewarm(self, conversation_id: uuid.UUID) -> None:
+        self.started.append(conversation_id)
+
+    def pop_pending_messages(self, conversation_id: uuid.UUID) -> list[str]:
+        return self.pending_messages.pop(conversation_id, [])
+
+
+@pytest.mark.asyncio
+async def test_handle_user_message_queues_until_runner_is_ready() -> None:
+    """Early submits should be accepted and queued until warmup finishes."""
+    conversation_id = uuid.uuid4()
+    state = MagicMock()
+    state.conversation_id = conversation_id
+    run_worker = MagicMock()
+    runner = _FakeRunner(is_ready=False)
+    runners = _FakeRunners(runner)
+    controller = UserMessageController(
+        state=state,
+        runners=runners,
+        run_worker=run_worker,
+        headless_mode=False,
+    )
+
+    await controller.handle_user_message("hello")
+
+    runner.visualizer.render_user_message.assert_called_once_with("hello")
+    state.set_conversation_title.assert_called_once_with("hello")
+    assert runners.enqueued == [(conversation_id, "hello")]
+    assert runners.started == [conversation_id]
+    run_worker.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_user_message_starts_processing_when_runner_is_ready() -> None:
+    """Ready runners should process immediately without queueing."""
+    conversation_id = uuid.uuid4()
+    state = MagicMock()
+    state.conversation_id = conversation_id
+    run_worker = MagicMock()
+    runner = _FakeRunner(is_ready=True)
+    runners = _FakeRunners(runner)
+    controller = UserMessageController(
+        state=state,
+        runners=runners,
+        run_worker=run_worker,
+        headless_mode=False,
+    )
+
+    await controller.handle_user_message("hello")
+
+    assert runners.enqueued == []
+    assert runners.started == []
+    run_worker.assert_called_once_with(
+        runner.process_message_job,
+        name="process_message",
+    )
+
+
+@pytest.mark.asyncio
+async def test_flush_pending_messages_starts_batch_processing() -> None:
+    """Queued pre-rendered messages should flush in a single worker job."""
+    conversation_id = uuid.uuid4()
+    state = MagicMock()
+    state.conversation_id = conversation_id
+    run_worker = MagicMock()
+    runner = _FakeRunner(is_ready=True)
+    runners = _FakeRunners(runner)
+    runners.pending_messages[conversation_id] = ["one", "two"]
+    controller = UserMessageController(
+        state=state,
+        runners=runners,
+        run_worker=run_worker,
+        headless_mode=True,
+    )
+
+    await controller.flush_pending_messages(conversation_id)
+
+    run_worker.assert_called_once_with(
+        runner.process_pending_job,
+        name="process_pending_messages",
+    )

--- a/tests/tui/test_splash.py
+++ b/tests/tui/test_splash.py
@@ -1,12 +1,8 @@
 """Tests for splash screen and welcome message functionality."""
 
-import unittest.mock as mock
-
+from openhands_cli import __version__
 from openhands_cli.theme import OPENHANDS_THEME
-from openhands_cli.tui.content.splash import (
-    get_openhands_banner,
-    get_splash_content,
-)
+from openhands_cli.tui.content.splash import get_openhands_banner, get_splash_content
 from openhands_cli.version_check import VersionInfo
 
 
@@ -17,13 +13,10 @@ class TestGetOpenHandsBanner:
         """Test that banner contains OpenHands ASCII art."""
         banner = get_openhands_banner()
 
-        # Check that it's a string
         assert isinstance(banner, str)
-
-        # Check that it contains key elements of the ASCII art
         assert "___" in banner
-        assert "OpenHands" in banner or "_ __" in banner  # ASCII art representation
-        assert "\n" in banner  # Multi-line
+        assert "OpenHands" in banner or "_ __" in banner
+        assert "\n" in banner
 
     def test_banner_is_consistent(self):
         """Test that banner is consistent across calls."""
@@ -35,123 +28,77 @@ class TestGetOpenHandsBanner:
 class TestGetSplashContent:
     """Tests for get_splash_content function."""
 
-    def test_splash_content_with_conversation_id(self):
-        """Test splash content generation with conversation ID."""
-        with mock.patch(
-            "openhands_cli.tui.content.splash.check_for_updates"
-        ) as mock_check:
-            mock_check.return_value = VersionInfo(
-                current_version="1.0.0",
-                latest_version="1.0.0",
-                needs_update=False,
-                error=None,
-            )
+    def test_splash_content_with_default_version(self):
+        """Splash should render immediately without performing a version check."""
+        content = get_splash_content("test-123", theme=OPENHANDS_THEME)
 
-            content = get_splash_content("test-123", theme=OPENHANDS_THEME)
-
-            # Check basic structure
-            assert isinstance(content, dict)
-            assert "version" in content
-            assert "OpenHands CLI v1.0.0" in content["version"]
-            assert "status_text" in content
-            assert "All set up!" in content["status_text"]
-            assert "instructions_header" in content
-            assert "What do you want to build?" in content["instructions_header"]
-            assert "instructions" in content
-            assert (
-                "1. Ask questions, edit files, or run commands."
-                in content["instructions"][0]
-            )
-            assert (
-                "2. Use @ to look up a file in the folder structure"
-                in content["instructions"][1]
-            )
-            # Verify /help and /feedback are mentioned in instructions
-            assert "/help" in content["instructions"][2]
-            assert "/feedback" in content["instructions"][2]
-
-            # Should contain conversation ID
-            assert "conversation_text" in content
-            assert "Initialized conversation" in content["conversation_text"]
-            assert "test-123" in content["conversation_text"]
+        assert isinstance(content, dict)
+        assert content["version"] == f"OpenHands CLI v{__version__}"
+        assert content["update_notice"] is None
+        assert "All set up!" in content["status_text"]
+        assert "Initialized conversation" in content["conversation_text"]
+        assert "test-123" in content["conversation_text"]
 
     def test_splash_content_structure(self):
         """Test the structure of splash content."""
-        with mock.patch(
-            "openhands_cli.tui.content.splash.check_for_updates"
-        ) as mock_check:
-            mock_check.return_value = VersionInfo(
-                current_version="1.0.0",
-                latest_version="1.0.0",
-                needs_update=False,
-                error=None,
-            )
+        content = get_splash_content("test-123", theme=OPENHANDS_THEME)
 
-            content = get_splash_content("test-123", theme=OPENHANDS_THEME)
+        expected_keys = [
+            "banner",
+            "version",
+            "status_text",
+            "conversation_text",
+            "conversation_id",
+            "instructions_header",
+            "instructions",
+            "update_notice",
+            "critic_notice",
+        ]
 
-            # Check that all expected keys are present
-            expected_keys = [
-                "banner",
-                "version",
-                "status_text",
-                "conversation_text",
-                "conversation_id",
-                "instructions_header",
-                "instructions",
-            ]
+        for key in expected_keys:
+            assert key in content
 
-            for key in expected_keys:
-                assert key in content
+        assert isinstance(content["banner"], str)
+        assert isinstance(content["version"], str)
+        assert isinstance(content["status_text"], str)
+        assert isinstance(content["conversation_text"], str)
+        assert isinstance(content["conversation_id"], str)
+        assert isinstance(content["instructions_header"], str)
+        assert isinstance(content["instructions"], list)
 
-            # Check types
-            assert isinstance(content["banner"], str)
-            assert isinstance(content["version"], str)
-            assert isinstance(content["status_text"], str)
-            assert isinstance(content["conversation_text"], str)
-            assert isinstance(content["conversation_id"], str)
-            assert isinstance(content["instructions_header"], str)
-            assert isinstance(content["instructions"], list)
+    def test_splash_content_includes_update_notice_when_version_info_arrives(self):
+        """Update text should render only after background version info arrives."""
+        version_info = VersionInfo(
+            current_version="1.0.0",
+            latest_version="1.1.0",
+            needs_update=True,
+            error=None,
+        )
 
-    def test_splash_content_includes_banner(self):
-        """Test that splash content includes the OpenHands banner."""
-        with mock.patch(
-            "openhands_cli.tui.content.splash.check_for_updates"
-        ) as mock_check:
-            mock_check.return_value = VersionInfo(
-                current_version="1.0.0",
-                latest_version="1.0.0",
-                needs_update=False,
-                error=None,
-            )
+        content = get_splash_content(
+            "test-123",
+            theme=OPENHANDS_THEME,
+            version_info=version_info,
+        )
 
-            content = get_splash_content("test-123", theme=OPENHANDS_THEME)
-
-            # Should include banner elements
-            banner = content["banner"]
-            assert "OpenHands" in banner or "_ __" in banner
-            assert "___" in banner
+        assert content["version"] == "OpenHands CLI v1.0.0"
+        assert "1.1.0" in content["update_notice"]
+        assert "uv tool upgrade openhands" in content["update_notice"]
 
     def test_splash_content_with_colors(self):
-        """Test that splash content includes color markup."""
-        with mock.patch(
-            "openhands_cli.tui.content.splash.check_for_updates"
-        ) as mock_check:
-            mock_check.return_value = VersionInfo(
-                current_version="1.0.0",
-                latest_version="1.0.0",
-                needs_update=False,
-                error=None,
-            )
+        """Test that splash content includes Rich markup."""
+        content = get_splash_content(
+            "test-123",
+            theme=OPENHANDS_THEME,
+            has_critic=True,
+        )
 
-            content = get_splash_content("test-123", theme=OPENHANDS_THEME)
-
-            # Should contain Rich markup for colors
-            assert "[" in content["banner"] and "]" in content["banner"]
-            assert (
-                "[" in content["instructions_header"]
-                and "]" in content["instructions_header"]
-            )
-            assert (
-                "[" in content["conversation_text"]
-                and "]" in content["conversation_text"]
-            )
+        assert "[" in content["banner"] and "]" in content["banner"]
+        assert (
+            "[" in content["instructions_header"]
+            and "]" in content["instructions_header"]
+        )
+        assert (
+            "[" in content["conversation_text"] and "]" in content["conversation_text"]
+        )
+        assert "Critic + Iterative Refinement Mode" in content["critic_notice"]


### PR DESCRIPTION
## Summary
- render the TUI splash immediately instead of blocking on startup warmup work
- move version checking and conversation runner warmup off the critical path
- queue early user messages until warmup completes, then flush them automatically
- make splash/status content reactively update when version/resource info arrives
- add and update tests for splash rendering, queued startup messages, and compatibility paths

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest tests/tui/test_splash.py tests/tui/core/test_user_message_controller.py tests/tui/test_headless_mode.py tests/tui/test_loaded_resources.py tests/snapshots/e2e/test_app_initial_state.py tests/tui/test_commands.py -k "initial_state or new_command or test_splash or test_headless_mode or test_loaded_resources or test_user_message_controller" -q`
- `uv run pyright tests/tui/core/test_user_message_controller.py`
- `uv run pytest tests/tui/core/test_user_message_controller.py -q`

## Notes
- no PR template was present in the repository, so this description follows the repo contribution guidance
- PR is opened as a draft because it has not been explicitly marked ready for review

_This pull request description was created by an AI assistant (OpenHands) on behalf of the user._

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@tui/nonblocking-startup
```