### PR TITLE
chore: rename ALLHANDS_BOT_GITHUB_PAT to PAT_TOKEN

### DIFF
--- a/.github/workflows/bump-agent-sdk-version.yml
+++ b/.github/workflows/bump-agent-sdk-version.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Validate version format
               run: |
@@ -97,7 +97,7 @@ jobs:
               run: |
                   BRANCH_NAME="bump-agent-sdk-${{ inputs.version }}"
                   EXISTING_PR=$(curl -s \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:$BRANCH_NAME" \
                     | jq -r '.[0].html_url // "null"')
@@ -116,7 +116,7 @@ jobs:
               run: |
                   BRANCH_NAME="bump-agent-sdk-${{ inputs.version }}"
                   PR_RESPONSE=$(curl -s -X POST \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     https://api.github.com/repos/${{ github.repository }}/pulls \
                     -d '{

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -133,7 +133,7 @@ jobs:
 
                   # Check if a PR already exists for this version
                   EXISTING_PR=$(curl -s \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${BRANCH_NAME}" \
                     | jq -r '.[0].html_url // "null"')
@@ -156,7 +156,7 @@ jobs:
 
                   # Create draft PR using GitHub API
                   PR_RESPONSE=$(curl -s -X POST \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls" \
                     -d '{

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/update-install-website.yml
+++ b/.github/workflows/update-install-website.yml
@@ -13,8 +13,8 @@ on:
                 required: true
                 type: string
 
-# Note: This workflow requires ALLHANDS_BOT_GITHUB_PAT secret to have access to the All-Hands-AI/install-openhands-website repository
-# Create a Personal Access Token (PAT) with repo permissions and store it as ALLHANDS_BOT_GITHUB_PAT in repository secrets
+# Note: This workflow requires PAT_TOKEN secret to have access to the All-Hands-AI/install-openhands-website repository
+# Create a Personal Access Token (PAT) with repo permissions and store it as PAT_TOKEN in repository secrets
 permissions:
     contents: read
 
@@ -44,8 +44,8 @@ jobs:
 
             - name: Clone install-openhands-website repository
               run: |
-                  # Use ALLHANDS_BOT_GITHUB_PAT to clone the repository
-                  git clone https://${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}@github.com/All-Hands-AI/install-openhands-website.git website-repo
+                  # Use PAT_TOKEN to clone the repository
+                  git clone https://${{ secrets.PAT_TOKEN }}@github.com/All-Hands-AI/install-openhands-website.git website-repo
                   cd website-repo
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -82,7 +82,7 @@ jobs:
               run: |
                   # Check if a PR already exists for this version
                   EXISTING_PR=$(curl -s \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/All-Hands-AI/install-openhands-website/pulls?state=open&head=update-version-${{ steps.extract_version.outputs.version }}" \
                     | jq -r '.[0].html_url // "null"')
@@ -104,7 +104,7 @@ jobs:
 
                   # Create PR using GitHub API
                   curl -X POST \
-                    -H "Authorization: token ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
+                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     https://api.github.com/repos/All-Hands-AI/install-openhands-website/pulls \
                     -d '{


### PR DESCRIPTION
## Summary

Renames \`ALLHANDS_BOT_GITHUB_PAT\` → \`PAT_TOKEN\` in workflow files to standardise on the org-wide \`PAT_TOKEN\` secret name.

This is a mechanical rename only — no behaviour changes. Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).

PAT_TOKEN is an organization secret in OpenHands and is validated to exist. 

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@chore/rename-allhands-bot-github-pat-to-pat-token
```