### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC

### DIFF
--- a/.github/workflows/bump-agent-sdk-version.yml
+++ b/.github/workflows/bump-agent-sdk-version.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
 
             - name: Validate version format
               run: |
@@ -97,7 +97,7 @@ jobs:
               run: |
                   BRANCH_NAME="bump-agent-sdk-${{ inputs.version }}"
                   EXISTING_PR=$(curl -s \
-                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+                    -H "Authorization: token ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:$BRANCH_NAME" \
                     | jq -r '.[0].html_url // "null"')
@@ -116,7 +116,7 @@ jobs:
               run: |
                   BRANCH_NAME="bump-agent-sdk-${{ inputs.version }}"
                   PR_RESPONSE=$(curl -s -X POST \
-                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+                    -H "Authorization: token ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     https://api.github.com/repos/${{ github.repository }}/pulls \
                     -d '{

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -133,7 +133,7 @@ jobs:
 
                   # Check if a PR already exists for this version
                   EXISTING_PR=$(curl -s \
-                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+                    -H "Authorization: token ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${BRANCH_NAME}" \
                     | jq -r '.[0].html_url // "null"')
@@ -156,7 +156,7 @@ jobs:
 
                   # Create draft PR using GitHub API
                   PR_RESPONSE=$(curl -s -X POST \
-                    -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+                    -H "Authorization: token ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/pulls" \
                     -d '{

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Renames PAT secret references in workflow files to the scoped secret `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` as part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

- Replaces `secrets.PAT_TOKEN` / `secrets.ALLHANDS_BOT_GITHUB_PAT` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC`
- No logic changes

**Three scoped PAT identities:**
| Secret | Scope |
|---|---|
| `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` | Public repos |
| `OPENHANDS_BOT_GITHUB_PAT_PRIVATE` | Private repos |
| `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` | Cross-repo workflow dispatch |

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@chore/use-openhands_bot_github_pat_public
```