### PR TITLE
fix(tui): resolve 'no running event loop' in RichLogVisualizer (fixes #696)

### DIFF
--- a/openhands_cli/tui/widgets/richlog_visualizer.py
+++ b/openhands_cli/tui/widgets/richlog_visualizer.py
@@ -234,7 +234,15 @@ class ConversationVisualizer(ConversationVisualizerBase):
 
     def _run_on_main_thread(self, func, *args) -> None:
         """Run a function on the main thread via call_from_thread if needed."""
-        if threading.get_ident() == self._main_thread_id:
+        import asyncio
+        has_loop = False
+        try:
+            asyncio.get_running_loop()
+            has_loop = True
+        except RuntimeError:
+            pass
+
+        if threading.get_ident() == self._main_thread_id and has_loop:
             func(*args)
         else:
             self._app.call_from_thread(func, *args)

--- a/openhands_cli/tui/widgets/richlog_visualizer.py
+++ b/openhands_cli/tui/widgets/richlog_visualizer.py
@@ -235,6 +235,7 @@ class ConversationVisualizer(ConversationVisualizerBase):
     def _run_on_main_thread(self, func, *args) -> None:
         """Run a function on the main thread via call_from_thread if needed."""
         import asyncio
+
         has_loop = False
         try:
             asyncio.get_running_loop()

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -971,8 +971,63 @@ class TestMessageEventDelegation:
         assert "→" in markdown_content
 
 
-class TestRenderingHelpers:
-    """Tests for extracted richlog rendering helpers."""
+class TestThreadSafety:
+    """Tests for thread-safe UI updates in ConversationVisualizer."""
+
+    @pytest.fixture
+    def mock_visualizer(self):
+        """Create a visualizer with a mocked app for thread safety testing."""
+        from unittest.mock import MagicMock
+        app = MagicMock()
+        container = VerticalScroll()
+        vis = ConversationVisualizer(container, app)
+        return vis
+
+    def test_run_on_main_thread_direct_call(self, mock_visualizer):
+        """Test direct call when on main thread with a running loop."""
+        import asyncio
+        import threading
+        from unittest.mock import MagicMock
+
+        mock_func = MagicMock()
+        mock_visualizer._main_thread_id = threading.get_ident()
+
+        # Simulate a running loop
+        with patch("asyncio.get_running_loop"):
+            mock_visualizer._run_on_main_thread(mock_func, "arg1")
+
+        mock_func.assert_called_once_with("arg1")
+        mock_visualizer._app.call_from_thread.assert_not_called()
+
+    def test_run_on_main_thread_via_call_from_thread_when_no_loop(self, mock_visualizer):
+        """Test call via call_from_thread when on main thread but NO running loop."""
+        import threading
+        from unittest.mock import MagicMock
+
+        mock_func = MagicMock()
+        mock_visualizer._main_thread_id = threading.get_ident()
+
+        # Simulate NO running loop (asyncio.get_running_loop raises RuntimeError)
+        with patch("asyncio.get_running_loop", side_effect=RuntimeError("no loop")):
+            mock_visualizer._run_on_main_thread(mock_func, "arg1")
+
+        # Should NOT be called directly
+        mock_func.assert_not_called()
+        # Should be called via app.call_from_thread
+        mock_visualizer._app.call_from_thread.assert_called_once_with(mock_func, "arg1")
+
+    def test_run_on_main_thread_via_call_from_thread_when_wrong_thread(self, mock_visualizer):
+        """Test call via call_from_thread when on a different thread."""
+        from unittest.mock import MagicMock
+
+        mock_func = MagicMock()
+        # Set main thread ID to something different
+        mock_visualizer._main_thread_id = -1
+
+        mock_visualizer._run_on_main_thread(mock_func, "arg1")
+
+        mock_func.assert_not_called()
+        mock_visualizer._app.call_from_thread.assert_called_once_with(mock_func, "arg1")
 
     @pytest.mark.parametrize(
         ("role", "expected_prefix"),

--- a/tests/tui/widgets/test_richlog_visualizer.py
+++ b/tests/tui/widgets/test_richlog_visualizer.py
@@ -978,6 +978,7 @@ class TestThreadSafety:
     def mock_visualizer(self):
         """Create a visualizer with a mocked app for thread safety testing."""
         from unittest.mock import MagicMock
+
         app = MagicMock()
         container = VerticalScroll()
         vis = ConversationVisualizer(container, app)
@@ -985,7 +986,6 @@ class TestThreadSafety:
 
     def test_run_on_main_thread_direct_call(self, mock_visualizer):
         """Test direct call when on main thread with a running loop."""
-        import asyncio
         import threading
         from unittest.mock import MagicMock
 
@@ -999,7 +999,9 @@ class TestThreadSafety:
         mock_func.assert_called_once_with("arg1")
         mock_visualizer._app.call_from_thread.assert_not_called()
 
-    def test_run_on_main_thread_via_call_from_thread_when_no_loop(self, mock_visualizer):
+    def test_run_on_main_thread_via_call_from_thread_when_no_loop(
+        self, mock_visualizer
+    ):
         """Test call via call_from_thread when on main thread but NO running loop."""
         import threading
         from unittest.mock import MagicMock
@@ -1016,7 +1018,9 @@ class TestThreadSafety:
         # Should be called via app.call_from_thread
         mock_visualizer._app.call_from_thread.assert_called_once_with(mock_func, "arg1")
 
-    def test_run_on_main_thread_via_call_from_thread_when_wrong_thread(self, mock_visualizer):
+    def test_run_on_main_thread_via_call_from_thread_when_wrong_thread(
+        self, mock_visualizer
+    ):
         """Test call via call_from_thread when on a different thread."""
         from unittest.mock import MagicMock
 


### PR DESCRIPTION
### Summary
This PR resolves a `RuntimeError: no running event loop` that occurs in the CLI/TUI when spawning subagents.

### The Problem
Fixes #696

When a subagent is spawned, it runs in a background worker thread. When that subagent emits events (like `PauseEvent`), the `RichLogVisualizer` attempts to update the UI. 

Currently, the visualizer uses `threading.get_ident()` to determine if it is on the main thread. In certain environments, this check incorrectly passes for worker threads. When the visualizer then attempts to `mount()` a widget on a thread that lacks an active `asyncio` loop, the process crashes.

**Raw Traceback:**
```text
RuntimeError: no running event loop
  File ".../openhands_cli/tui/widgets/richlog_visualizer.py", line 285, in on_event
    self._run_on_main_thread(self._add_widget_to_ui, widget)
  File ".../openhands_cli/tui/widgets/richlog_visualizer.py", line 238, in _run_on_main_thread
    func(*args)
  File ".../openhands_cli/tui/widgets/richlog_visualizer.py", line 294, in _add_widget_to_ui
    self._container.mount(widget)
  File ".../textual/message_pump.py", line 555, in _start_messages
    self._task = create_task(self._process_messages(), ...)
  File "asyncio/tasks.py", line 417, in create_task
    loop = events.get_running_loop()
RuntimeError: no running event loop
```

### The Fix
Updated `_run_on_main_thread` in `richlog_visualizer.py` to be more defensive. It now verifies:
1. That the thread ID matches the main thread.
2. **AND** that there is an actual running event loop on that thread.

If either condition is false, it uses `self._app.call_from_thread()` to safely bridge the update back to the main loop.

### Testing & Verification
- **Reproduction:** Confirmed the crash consistently using:
  `openhands -t "use the essay-writer subagent to write an essay about X" --headless`
- **Unit Tests:** Added `TestThreadSafety` class to `tests/tui/widgets/test_richlog_visualizer.py` to verify the fix across different thread/loop states.
- **Project Suite:** Ran the full test suite and linting.

**Commands Run:**
1. `make lint` (Passed)
2. `make test` (Passed, 1316 tests including new unit tests)