### PR TITLE
fix: emit JSONL in --json mode (#676)

### DIFF
--- a/openhands_cli/utils.py
+++ b/openhands_cli/utils.py
@@ -264,6 +264,4 @@ def json_callback(event: Event) -> None:
         return
 
     data = event.model_dump()
-    pretty_json = json.dumps(data, indent=2, sort_keys=True)
-    print("--JSON Event--")
-    print(pretty_json)
+    print(json.dumps(data))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,12 +194,9 @@ class TestJsonCallback:
         with patch("builtins.print") as mock_print:
             json_callback(message_event)
 
-            # Should have two print calls: header and JSON
-            assert mock_print.call_count == 2
-            mock_print.assert_any_call("--JSON Event--")
-
-            # Verify valid JSON output
-            json_output = mock_print.call_args_list[1][0][0]
+            # Should emit a single JSONL line per event
+            mock_print.assert_called_once()
+            json_output = mock_print.call_args[0][0]
             parsed_json = json.loads(json_output)
             assert isinstance(parsed_json, dict)
 
@@ -216,11 +213,8 @@ class TestJsonCallback:
             json_callback(event)
 
             # Verify the output structure
-            assert mock_print.call_count == 2
-            mock_print.assert_any_call("--JSON Event--")
-
-            # Get and validate the JSON output
-            json_output = mock_print.call_args_list[1][0][0]
+            mock_print.assert_called_once()
+            json_output = mock_print.call_args[0][0]
             parsed_json = json.loads(json_output)
 
             # Verify essential fields are present


### PR DESCRIPTION
## Summary
- make `--json` emit one valid JSON object per line instead of pretty-printed multi-line blocks
- remove the `--JSON Event--` delimiter output so the stream matches the documented JSONL contract
- update `json_callback` tests to assert a single `print` call per event and valid JSON parsing

## Testing
- `make format`
- `make lint`
- `uv run env HOME="$(mktemp -d)" pytest tests/test_utils.py -q`

Closes #676
