### PR TITLE
fix: migrate login to V1 settings/users endpoints

### DIFF
--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -1,6 +1,7 @@
 """API client for fetching user data after OAuth authentication."""
 
 import html
+import json
 from typing import Any
 
 import httpx
@@ -31,6 +32,27 @@ def get_settings_path() -> str:
     return f"{get_persistence_dir()}/{AGENT_SETTINGS_PATH}"
 
 
+def _flatten_v1_settings(payload: dict[str, Any]) -> dict[str, Any]:
+    """Surface V1 nested settings fields under the legacy flat keys.
+
+    The /api/v1/settings response nests agent/LLM data under
+    ``agent_settings``, but the rest of the CLI still consumes the flat
+    keys (``llm_model``, ``llm_base_url``, ``agent``). Promote those without
+    discarding the original payload.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    flat = dict(payload)
+    agent_settings = payload.get("agent_settings")
+    if isinstance(agent_settings, dict):
+        flat.setdefault("agent", agent_settings.get("agent"))
+        llm = agent_settings.get("llm")
+        if isinstance(llm, dict):
+            flat.setdefault("llm_model", llm.get("model"))
+            flat.setdefault("llm_base_url", llm.get("base_url"))
+    return flat
+
+
 class OpenHandsApiClient(BaseHttpClient):
     """Client for making authenticated API calls to OpenHands server."""
 
@@ -53,7 +75,16 @@ class OpenHandsApiClient(BaseHttpClient):
                     f"Authentication failed for {path!r}: {e}"
                 ) from e
             raise ApiClientError(f"Request to {path!r} failed: {e}") from e
-        return response.json()
+        try:
+            return response.json()
+        except json.JSONDecodeError as e:
+            # The SaaS server returns the SPA index.html (HTTP 200) for
+            # unknown API paths, which yields an opaque JSONDecodeError.
+            # Surface a useful message naming the path and status instead.
+            raise ApiClientError(
+                f"Request to {path!r} returned a non-JSON response "
+                f"(HTTP {response.status_code})"
+            ) from e
 
     async def get_user_info(self) -> dict[str, Any]:
         """Get user information from the API.
@@ -65,14 +96,15 @@ class OpenHandsApiClient(BaseHttpClient):
             UnauthenticatedError: If the user is not authenticated (401 response)
             ApiClientError: For other API errors
         """
-        return await self._get_json("/api/user/info")
+        return await self._get_json("/api/v1/users/me")
 
     async def get_llm_api_key(self) -> str | None:
         result = await self._get_json("/api/keys/llm/byor")
         return result.get("key")
 
     async def get_user_settings(self) -> dict[str, Any]:
-        return await self._get_json("/api/settings")
+        payload = await self._get_json("/api/v1/settings")
+        return _flatten_v1_settings(payload)
 
     async def create_conversation(
         self, json_data: dict[str, Any] | None = None

--- a/tests/auth/test_api_client.py
+++ b/tests/auth/test_api_client.py
@@ -90,23 +90,36 @@ class TestOpenHandsApiClient:
             assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_user_settings_success(self):
-        """Test successful user settings retrieval."""
+    async def test_get_user_settings_flattens_v1_payload(self):
+        """`/api/v1/settings` returns nested agent_settings; the client should
+        surface the legacy flat keys consumed by the rest of the CLI."""
         client = OpenHandsApiClient("https://api.example.com", "test-key")
 
-        expected_settings = {
-            "llm_model": "gpt-4o-mini",
-            "agent": "CodeActAgent",
+        v1_payload = {
             "language": "en",
+            "llm_api_key_set": True,
+            "agent_settings": {
+                "agent": "CodeActAgent",
+                "llm": {
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://llm-proxy.example.com",
+                },
+            },
         }
 
         with patch.object(client, "_get_json") as mock_get_json:
-            mock_get_json.return_value = expected_settings
+            mock_get_json.return_value = v1_payload
 
             result = await client.get_user_settings()
 
-            assert result == expected_settings
-            mock_get_json.assert_called_once_with("/api/settings")
+            mock_get_json.assert_called_once_with("/api/v1/settings")
+            assert result["llm_model"] == "gpt-4o-mini"
+            assert result["llm_base_url"] == "https://llm-proxy.example.com"
+            assert result["agent"] == "CodeActAgent"
+            assert result["language"] == "en"
+            assert result["llm_api_key_set"] is True
+            # Nested payload preserved for callers that need full data.
+            assert result["agent_settings"] == v1_payload["agent_settings"]
 
     @pytest.mark.asyncio
     async def test_get_user_info_success(self):
@@ -125,7 +138,25 @@ class TestOpenHandsApiClient:
             result = await client.get_user_info()
 
             assert result == expected_user_info
-            mock_get_json.assert_called_once_with("/api/user/info")
+            mock_get_json.assert_called_once_with("/api/v1/users/me")
+
+    @pytest.mark.asyncio
+    async def test_get_json_non_json_response(self):
+        """A 2xx response with a non-JSON body (e.g. SPA HTML fallback) must
+        raise ApiClientError, not leak the raw JSONDecodeError."""
+        client = OpenHandsApiClient("https://api.example.com", "test-key")
+
+        mock_response = httpx.Response(status_code=200)
+        mock_response._content = b"<!doctype html><html></html>"
+
+        with patch.object(client, "get") as mock_get:
+            mock_get.return_value = mock_response
+
+            with pytest.raises(
+                ApiClientError,
+                match=r"Request to '/test' returned a non-JSON response \(HTTP 200\)",
+            ):
+                await client._get_json("/test")
 
     @pytest.mark.asyncio
     async def test_get_json_401_error(self):


### PR DESCRIPTION
### Description

After OAuth device-flow authentication completes successfully, `uv run openhands login` crashes while fetching user data:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

at `openhands_cli/auth/api_client.py:56` in `_get_json` → `response.json()`.

### Steps to reproduce

1. `cd OpenHands-CLI`
2. `uv run openhands logout` (clear any stored token)
3. `uv run openhands login`
4. In the browser, click **Authorize Device**
5. Return to the terminal — observe the crash after `• Getting user settings...`

### Root cause

The CLI calls `GET /api/settings`, which the OpenHands SaaS server removed:

- `e38eda4ac` Migrate settings endpoints to V1 API (`/api/v1/settings`)
- `3b264dd41` Remove deprecated V0 FastAPI endpoints

The SaaS server mounts `SPAStaticFiles` as a fallback at `/`, so unknown API paths return the SPA `index.html` (HTTP 200, HTML body) instead of a JSON 404. `_make_request` does not raise (status is 2xx), then `response.json()` fails parsing `<!doctype html>…`. `/api/keys/llm/byor` keeps working because the enterprise router still serves that path, which is why the LLM-key step succeeds before the settings step crashes.

A second issue surfaces once the URL is corrected: V1 nests agent/LLM data under `agent_settings`, while the CLI consumes flat `llm_model` / `llm_base_url` / `agent` keys.

`/api/user/info` is the same V0-removed pattern and would re-introduce the same crash on returning users via `is_token_valid`.

### Summary

- `openhands login` crashed after OAuth with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` because the SaaS server removed `/api/settings` (and `/api/user/info`) during the V1 migration; the SPA static fallback returns `index.html` for unknown API paths, so `response.json()` parsed HTML.
- Repointed `get_user_settings` to `/api/v1/settings` and `get_user_info` to `/api/v1/users/me`. Added `_flatten_v1_settings` to map the nested `agent_settings.{agent,llm.model,llm.base_url}` payload onto the flat keys the rest of the CLI consumes, so `_print_settings_summary`, `_ask_user_consent_for_overwrite`, and `AgentStore.create_and_save_from_settings` keep working unchanged.
- Hardened `_get_json` to raise `ApiClientError` (with the path and HTTP status) on non-JSON 2xx bodies instead of leaking a `JSONDecodeError` — so the next time a route gets renamed, the failure mode is legible.

### Demo Video

https://github.com/user-attachments/assets/3d69f7d3-eb78-4e0e-9b9a-8922c3bdbf07

Resolves #705
