### PR TITLE
fix: bind serve port to localhost

### DIFF
--- a/openhands_cli/gui_launcher.py
+++ b/openhands_cli/gui_launcher.py
@@ -187,7 +187,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     docker_cmd.extend(
         [
             "-p",
-            "3000:3000",
+            "127.0.0.1:3000:3000",
             "--add-host",
             "host.docker.internal:host-gateway",
             "--name",

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -26,10 +26,18 @@ class TestFormatDockerCommand:
                 "Running Docker command: docker run hello-world",
             ),
             (
-                ["docker", "run", "-it", "--rm", "-p", "3000:3000", "openhands:latest"],
+                [
+                    "docker",
+                    "run",
+                    "-it",
+                    "--rm",
+                    "-p",
+                    "127.0.0.1:3000:3000",
+                    "openhands:latest",
+                ],
                 (
-                    "Running Docker command: docker run -it --rm -p 3000:3000 "
-                    "openhands:latest"
+                    "Running Docker command: docker run -it --rm -p "
+                    "127.0.0.1:3000:3000 openhands:latest"
                 ),
             ),
             ([], "Running Docker command: "),
@@ -183,6 +191,7 @@ class TestLaunchGuiServer:
             assert run_cmd[0:2] == ["docker", "run"]
             # Verify --pull=always is in the command
             assert "--pull=always" in run_cmd
+            assert run_cmd[run_cmd.index("-p") + 1] == "127.0.0.1:3000:3000"
 
             if mount_cwd:
                 assert "SANDBOX_VOLUMES=/current/dir:/workspace:rw" in " ".join(run_cmd)


### PR DESCRIPTION
## Summary
- Bind the `openhands serve` Docker port mapping to `127.0.0.1:3000:3000` instead of all host interfaces.
- Update GUI launcher coverage so the localhost-only mapping is asserted.

Fixes #706

## Tests
- `PATH="/Users/vandit/Documents/Codex/2026-05-06/hey-i-need-you-to-run/.tools:$PATH" make lint`
- `PATH="/Users/vandit/Documents/Codex/2026-05-06/hey-i-need-you-to-run/.tools:$PATH" make test`
- `/Users/vandit/Documents/Codex/2026-05-06/hey-i-need-you-to-run/.tools/uv run --locked pytest tests/test_gui_launcher.py -q`
- `/Users/vandit/Documents/Codex/2026-05-06/hey-i-need-you-to-run/.tools/uv run --locked ruff check tests/test_gui_launcher.py`
- `/Users/vandit/Documents/Codex/2026-05-06/hey-i-need-you-to-run/.tools/uv run --locked ruff format --check openhands_cli/gui_launcher.py tests/test_gui_launcher.py`
- `git diff --check`
