### PR TITLE
docs: add contributor and development guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,40 @@
-AGENTS.md
+# Contributing to OpenHands CLI
+
+Thanks for helping improve OpenHands CLI.
+
+OpenHands CLI is the standalone terminal interface for OpenHands. This repo owns the Textual TUI, the browser-served view behind `openhands web`, packaging for the standalone binary, and the CLI-specific workflows around those surfaces.
+
+## Start with the shared OpenHands contribution guide
+
+The shared OpenHands contribution guide is the source of truth for the overall contribution process and should stay up to date in the docs repo:
+
+- Source of truth: https://github.com/OpenHands/docs/blob/main/overview/contributing.mdx
+
+If a change belongs in the shared contributor guidance for all OpenHands repositories, update that docs page rather than duplicating the same detail here.
+
+## What this repo adds on top
+
+This file is intentionally short. It covers the repo-specific pointers contributors need before opening a PR here:
+
+- OpenHands CLI is a Textual TUI project, so UI changes often need snapshot coverage in addition to normal pytest coverage.
+- Some changes need validation against the packaged executable, not just the Python entrypoint.
+- The detailed local setup, run loops, testing matrix, and packaging notes for this repo live in [Development.md](Development.md).
+
+## Before you open a pull request
+
+1. Read the shared OpenHands contributing guide above.
+2. Follow [Development.md](Development.md) for local setup and validation commands.
+3. Keep the PR focused and explain the user-visible effect of the change.
+4. Run the relevant checks for the files you touched:
+   - `make lint`
+   - `make test`
+   - `make test-snapshots` for TUI layout or rendering changes
+   - `make test-binary` for binary, ACP, auth, packaging, or end-to-end CLI flows
+5. If you changed the UI, include screenshots or snapshot updates so reviewers can see the result.
+
+## Questions or discussion
+
+- Open an issue in this repository for bugs or feature requests.
+- Join the community on Slack: https://openhands.dev/joinslack
+
+Thanks again for contributing.

--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,261 @@
+# Development Guide
+
+This guide is for contributors editing source code in OpenHands CLI.
+
+For the shared OpenHands contribution process, start with
+[CONTRIBUTING.md](CONTRIBUTING.md). That file points to the canonical
+OpenHands-wide contributor guide. This document is the repo-specific companion
+for local setup, TUI development, testing, and packaging workflows.
+
+## What lives in this repo
+
+OpenHands CLI includes:
+
+- the main Textual TUI (`openhands`)
+- the browser-served Textual view (`openhands web`)
+- the ACP entrypoint (`openhands-acp`)
+- packaging for the standalone executable (`openhands-cli.spec`, `build.sh`)
+- CLI-specific tests, snapshots, and end-to-end coverage
+
+## Prerequisites
+
+- Python 3.12
+- `uv` 0.11.6 or newer
+- Git
+- `tmux` is recommended for interactive TUI work so you can detach and resume
+  sessions
+
+If `uv` is not installed yet, use:
+
+```bash
+make install-uv
+```
+
+## Initial setup
+
+```bash
+git clone https://github.com/<your-user>/openhands-cli.git
+cd openhands-cli
+make build
+```
+
+`make build` will:
+
+- verify your `uv` version
+- install development dependencies with `uv sync --dev`
+- install pre-commit hooks
+
+## Repository layout
+
+```text
+openhands-cli/
+├── openhands_cli/      # CLI, TUI, ACP, auth, MCP, cloud integrations
+├── tests/              # Unit, integration, and snapshot-adjacent tests
+├── tui_e2e/            # End-to-end tests against the packaged executable
+├── scripts/            # Development helpers
+├── hooks/              # PyInstaller/runtime hooks
+├── build.sh            # Binary build entrypoint
+├── openhands-cli.spec  # PyInstaller spec file
+└── Makefile            # Common development commands
+```
+
+Important source areas:
+
+- `openhands_cli/tui/` for Textual widgets, screens, styling, and layout
+- `openhands_cli/auth/` for authentication flows
+- `openhands_cli/mcp/` for MCP configuration and UX
+- `openhands_cli/cloud/` for cloud-specific behavior
+- `openhands_cli/conversations/` for conversation management
+
+## Daily development workflow
+
+### Recommended fast loop for TUI work
+
+```bash
+make run-watch
+```
+
+This is the fastest iteration path for most TUI changes. It watches
+`openhands_cli/` and restarts the app when `.py` or `.tcss` files change.
+
+### Other useful run modes
+
+```bash
+make run
+```
+
+Runs the normal interactive TUI.
+
+```bash
+uv run openhands --exit-without-confirmation
+```
+
+Useful for automation-driven runs. Once the TUI is active, quit with `Ctrl+Q`.
+`Ctrl+C` is usually not enough.
+
+```bash
+openhands web
+```
+
+Runs the browser-served Textual view.
+
+```bash
+uv run openhands-acp
+```
+
+Runs the ACP entrypoint.
+
+## Code quality
+
+### Formatting and linting
+
+```bash
+make lint
+make format
+uv run pre-commit run --all-files
+```
+
+Notes:
+
+- `make lint` runs the repo lint target and should be part of your normal
+  pre-PR validation.
+- `make format` formats code under `openhands_cli/`.
+- `pre-commit` is the broadest local check and is useful before pushing.
+
+### Typing
+
+Use modern Python typing in new code where practical:
+
+- prefer `X | None` over `Optional[X]`
+- add type hints on new public functions and interfaces
+
+## Testing
+
+OpenHands CLI has multiple testing layers. The right validation depends on what
+kind of change you made.
+
+### Standard test suite
+
+```bash
+make test
+```
+
+This runs the main pytest suite and skips snapshot tests.
+
+Use this for:
+
+- business logic changes
+- command handling changes
+- non-visual CLI behavior
+- refactors in `openhands_cli/` that do not alter rendering
+
+### Snapshot tests
+
+```bash
+make test-snapshots
+```
+
+Snapshot tests are the primary visual regression checks for the Textual UI.
+Run them when you change:
+
+- widget layout
+- styling or `.tcss`
+- screen composition
+- rendered output in the TUI
+
+If the UI change is intentional, update snapshots with:
+
+```bash
+uv run pytest tests/snapshots --snapshot-update
+```
+
+Snapshot files live under:
+
+- `tests/snapshots/__snapshots__/test_app_snapshots/`
+- `tests/snapshots/__snapshots__/test_visualizer_snapshots/`
+
+When adding new snapshot tests:
+
+- keep terminal size fixed
+- mock external dependencies so output stays deterministic
+- prefer targeted unit tests alongside snapshots when the logic is non-visual
+
+### Binary end-to-end tests
+
+```bash
+make test-binary
+```
+
+These tests cover the packaged executable in `tui_e2e/` and are the right check
+for changes that affect:
+
+- packaging or startup
+- ACP flows
+- auth and connection flows
+- end-to-end CLI behavior
+- code paths that differ between source execution and the frozen binary
+
+Binary tests can use a mock OpenAI-compatible LLM server for deterministic test
+runs. When configuring the mock model, use `openai/gpt-4o-mock` so LiteLLM sees
+an explicit provider prefix.
+
+### Which checks should I run?
+
+As a rule of thumb:
+
+- docs-only changes: run `uv run pre-commit run --files ...` on the changed docs
+- Python logic changes: run `make test`
+- TUI or styling changes: run `make test` and `make test-snapshots`
+- binary, ACP, auth, or packaging changes: run `make test` and `make test-binary`
+- broad changes: run `make test-all` and add any extra targeted checks that fit
+  the affected area
+
+## Building the standalone executable
+
+```bash
+./build.sh --install-pyinstaller
+```
+
+Use this when you touch:
+
+- `openhands-cli.spec`
+- `hooks/`
+- runtime packaging behavior
+- assets or imports that may behave differently in a frozen binary
+
+If a dependency works in source mode but not in the executable, inspect:
+
+- hidden imports in `openhands-cli.spec`
+- PyInstaller hooks in `hooks/`
+- whether the affected code uses dynamic imports or runtime-discovered assets
+
+## Pull requests
+
+Before opening a PR, make sure you have:
+
+1. kept the scope focused
+2. run the relevant validation for the code you changed
+3. documented manual testing for user-facing changes
+4. included screenshots or snapshot updates for TUI changes when appropriate
+
+The PR template expects:
+
+- why the change is needed
+- a short summary of what changed
+- issue reference(s)
+- explicit test steps
+- screenshots or video for UI changes when relevant
+
+## When to update which document
+
+- update `CONTRIBUTING.md` only when the repo-specific contributor entrypoint
+  needs to change
+- update the shared OpenHands contributor guidance in the docs repo when the
+  process should apply across repositories
+- update this `Development.md` when the local setup, testing workflow, TUI
+  development loop, or packaging guidance for OpenHands CLI changes
+
+## Need help?
+
+- Open an issue in this repository
+- Join Slack: https://openhands.dev/joinslack

--- a/Development.md
+++ b/Development.md
@@ -117,17 +117,24 @@ uv run pre-commit run --all-files
 
 Notes:
 
-- `make lint` runs the repo lint target and should be part of your normal
-  pre-PR validation.
-- `make format` formats code under `openhands_cli/`.
-- `pre-commit` is the broadest local check and is useful before pushing.
+- `make lint` is a fast Ruff-only pass over `openhands_cli/`.
+- `make format` formats Python files under `openhands_cli/`.
+- `uv run pre-commit run --all-files` is the closest local match to the lint CI
+  job and is the better final check before pushing, especially when you touch
+  files outside `openhands_cli/`.
 
 ### Typing
+
+```bash
+uv run pyright
+```
 
 Use modern Python typing in new code where practical:
 
 - prefer `X | None` over `Optional[X]`
 - add type hints on new public functions and interfaces
+- run `uv run pyright` for Python feature work, refactors, and bug fixes that
+  could affect typed interfaces
 
 ## Testing
 
@@ -182,18 +189,33 @@ When adding new snapshot tests:
 
 ### Binary end-to-end tests
 
+For authoritative binary validation, use the build script:
+
 ```bash
-make test-binary
+./build.sh --install-pyinstaller
 ```
 
-These tests cover the packaged executable in `tui_e2e/` and are the right check
-for changes that affect:
+That command builds the standalone executable and then runs the `tui_e2e`
+runner against the built `dist/` binary. It is the right check for changes that
+affect:
 
 - packaging or startup
 - ACP flows
 - auth and connection flows
 - end-to-end CLI behavior
 - code paths that differ between source execution and the frozen binary
+
+If you already have a fresh `dist/` build and only want to rerun the binary test
+runner, use:
+
+```bash
+uv run python build.py --no-build
+```
+
+`make test-binary` currently runs `pytest tui_e2e`, which is useful while
+editing the `tui_e2e` modules themselves, but it is not the best pass/fail gate
+for feature or bug-fix validation because the authoritative binary checks live
+in `build.py`.
 
 Binary tests can use a mock OpenAI-compatible LLM server for deterministic test
 runs. When configuring the mock model, use `openai/gpt-4o-mock` so LiteLLM sees
@@ -203,12 +225,11 @@ an explicit provider prefix.
 
 As a rule of thumb:
 
-- docs-only changes: run `uv run pre-commit run --files ...` on the changed docs
-- Python logic changes: run `make test`
-- TUI or styling changes: run `make test` and `make test-snapshots`
-- binary, ACP, auth, or packaging changes: run `make test` and `make test-binary`
-- broad changes: run `make test-all` and add any extra targeted checks that fit
-  the affected area
+- docs-only changes: run `uv run pre-commit run --files <changed-docs>`
+- Python logic changes: run `make test` and `uv run pyright`
+- TUI or styling changes: run `make test`, `make test-snapshots`, and `uv run pyright`
+- binary, ACP, auth, or packaging changes: run `make test`, `uv run pyright`, and `./build.sh --install-pyinstaller`
+- broad changes: run the relevant checks above rather than relying on a single catch-all command
 
 ## Building the standalone executable
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ openhands --resume --last       # resume most recent
 
 For complete documentation, visit https://docs.openhands.dev/openhands/usage/cli.
 
+## Contributing
+
+Want to contribute to OpenHands CLI?
+
+- Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the high-level contribution process.
+- Use [Development.md](Development.md) for local setup, TUI workflows, snapshot testing, and binary validation.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested the development.md process.
- [x] A human has read the new documents.
---

## Why

The CLI repo needs contributor-facing docs that are easier to navigate and maintain. The current `CONTRIBUTING.md` was a symlink to `AGENTS.md`, which mixed agent guidance with human contributor guidance and made it hard to point contributors at a clear source of truth.

This PR takes a first pass at splitting responsibilities:

- `CONTRIBUTING.md` becomes a short contributor entrypoint for this repo
- shared contribution guidance points to the OpenHands docs source of truth
- `Development.md` holds the detailed, repo-specific workflow for local setup, TUI iteration, snapshot tests, binary tests, and packaging notes

Closes #720.

## Summary

- replace the `CONTRIBUTING.md -> AGENTS.md` symlink with a real high-level `CONTRIBUTING.md`
- add a first-pass `Development.md` for OpenHands CLI contributor workflows
- add README links so contributors can discover both docs from the main repo entrypoint

## Issue Number

- #720

## How to Test

You can manually review the three files
https://github.com/jamiechicago312/OpenHands-CLI/blob/jamie/docs-contributor-guides/README.md#contributing
https://github.com/jamiechicago312/OpenHands-CLI/blob/jamie/docs-contributor-guides/CONTRIBUTING.md
https://github.com/jamiechicago312/OpenHands-CLI/blob/jamie/docs-contributor-guides/Development.md

## Video/Screenshots

Not applicable for this docs-only PR.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- I had to use a newer user-local `uv` binary (`0.11.10`) because the system `uv` was `0.11.5` and `make build` requires `0.11.6+` in this repo.
- _This PR was created by an AI agent (OpenHands) on behalf of the user._
