### PR TITLE
auth: tolerate settings sync failures after login

### DIFF
--- a/openhands_cli/auth/api_client.py
+++ b/openhands_cli/auth/api_client.py
@@ -327,14 +327,22 @@ async def fetch_user_data_after_oauth(
 
         # Fetch user settings
         console_print("• Getting user settings...", style=OPENHANDS_THEME.secondary)
-        settings = await client.get_user_settings()
-
-        if settings:
-            _print_settings_summary(settings)
-        else:
+        settings: dict[str, Any] | None
+        try:
+            settings = await client.get_user_settings()
+        except ApiClientError as e:
+            settings = None
             console_print(
-                "  ! No user settings available", style=OPENHANDS_THEME.warning
+                f"  ! Could not fetch user settings: {e}",
+                style=OPENHANDS_THEME.warning,
             )
+        else:
+            if settings:
+                _print_settings_summary(settings)
+            else:
+                console_print(
+                    "  ! No user settings available", style=OPENHANDS_THEME.warning
+                )
 
         user_data = {
             "llm_api_key": llm_api_key,

--- a/tests/auth/test_api_client.py
+++ b/tests/auth/test_api_client.py
@@ -307,6 +307,33 @@ class TestHelperFunctions:
                 assert result == expected_result
 
     @pytest.mark.asyncio
+    async def test_fetch_user_data_after_oauth_settings_api_error_is_nonfatal(self):
+        """Settings sync failures should not fail the completed login flow."""
+        server_url = "https://api.example.com"
+        api_key = "test-api-key"
+
+        with patch(
+            "openhands_cli.auth.api_client.OpenHandsApiClient"
+        ) as mock_client_class:
+            with patch(
+                "openhands_cli.auth.api_client.create_and_save_agent_configuration"
+            ) as mock_create_and_save:
+                with patch("openhands_cli.auth.api_client.console_print"):
+                    mock_client = AsyncMock()
+                    mock_client_class.return_value = mock_client
+
+                    mock_client.get_llm_api_key.return_value = "llm-key-123"
+                    mock_client.get_user_settings.side_effect = ApiClientError(
+                        "Request to '/api/v1/settings' returned a non-JSON response"
+                    )
+
+                    result = await fetch_user_data_after_oauth(server_url, api_key)
+
+                    expected_result = {"llm_api_key": "llm-key-123", "settings": None}
+                    assert result == expected_result
+                    mock_create_and_save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_fetch_user_data_after_oauth_agent_creation_error(self):
         """Test user data fetching when agent creation fails."""
         server_url = "https://api.example.com"


### PR DESCRIPTION
## Summary
- Treat settings sync API errors as a warning after OAuth instead of failing the post-login data fetch.
- Skip local agent configuration when settings cannot be fetched, while preserving the retrieved LLM key in the returned data.
- Add regression coverage for settings API failures during post-OAuth user data fetch.

## Context
Refs #725. This hardens the login flow against settings endpoint failures, but the reproduced local traceback is from the currently published `openhands` wheel, which still contains the pre-#711 auth client that calls `/api/settings` and depends on `openhands-sdk==1.19.1`.

The current `main` branch already calls `/api/v1/settings` and depends on `openhands-sdk==1.21.0`, but the CLI package version remains `1.15.1`, so `openhands --version` alone does not distinguish the stale PyPI wheel from the current checkout.

## Tests
- `make lint`
- `make test`