### PR TITLE
fix: allow local models without API keys

### DIFF
--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, SecretStr
 from rich.console import Console
@@ -134,6 +135,51 @@ ENV_LLM_BASE_URL = "LLM_BASE_URL"
 ENV_LLM_MODEL = "LLM_MODEL"
 
 
+_PROVIDERS_WITH_OPTIONAL_API_KEYS = {
+    "bedrock",
+    "ollama",
+    "sagemaker",
+    "vertex_ai",
+    "vertex_ai_beta",
+}
+_LOCAL_BASE_URL_HOSTS = {
+    "0.0.0.0",
+    "127.0.0.1",
+    "::1",
+    "host.docker.internal",
+    "localhost",
+}
+
+
+def base_url_uses_local_llm(base_url: str | None) -> bool:
+    """Return True when the base URL targets a local LLM endpoint."""
+    if not base_url:
+        return False
+
+    try:
+        parsed = urlparse(base_url)
+    except ValueError:
+        return False
+
+    hostname = parsed.hostname
+    if hostname is None:
+        return False
+
+    return hostname.lower() in _LOCAL_BASE_URL_HOSTS
+
+
+def model_requires_api_key(model: str | None, base_url: str | None = None) -> bool:
+    """Return whether the given model/base_url combination requires an API key."""
+    if base_url_uses_local_llm(base_url):
+        return False
+
+    if not model:
+        return True
+
+    provider = model.split("/", 1)[0].lower()
+    return provider not in _PROVIDERS_WITH_OPTIONAL_API_KEYS
+
+
 class MissingEnvironmentVariablesError(Exception):
     """Raised when required environment variables are missing for headless mode.
 
@@ -225,10 +271,10 @@ class LLMEnvOverrides(BaseModel):
 
     def require_for_headless(self) -> None:
         missing: list[str] = []
-        if self.api_key is None:
-            missing.append(ENV_LLM_API_KEY)
         if self.model is None:
             missing.append(ENV_LLM_MODEL)
+        elif model_requires_api_key(self.model, self.base_url) and self.api_key is None:
+            missing.append(ENV_LLM_API_KEY)
         if missing:
             raise MissingEnvironmentVariablesError(missing)
 
@@ -289,12 +335,15 @@ class AgentStore:
 
         # In env override mode, require enough info to create an agent.
         overrides.require_for_headless()
-        assert overrides.api_key is not None
         assert overrides.model is not None
 
         llm = LLM(
             model=overrides.model,
-            api_key=overrides.api_key.get_secret_value(),
+            api_key=(
+                overrides.api_key.get_secret_value()
+                if overrides.api_key is not None
+                else None
+            ),
             base_url=overrides.base_url,
             usage_id="agent",
         )

--- a/openhands_cli/tui/modals/settings/settings_screen.py
+++ b/openhands_cli/tui/modals/settings/settings_screen.py
@@ -33,7 +33,11 @@ from openhands_cli.tui.modals.settings.components import (
     CriticSettingsTab,
     SettingsTab,
 )
-from openhands_cli.tui.modals.settings.utils import SettingsFormData, save_settings
+from openhands_cli.tui.modals.settings.utils import (
+    SettingsFormData,
+    model_requires_api_key,
+    save_settings,
+)
 
 
 if TYPE_CHECKING:
@@ -215,9 +219,10 @@ class SettingsScreen(ModalScreen):
             self.api_key_input.placeholder = (
                 f"Current: {key_value[:3]}*** (leave empty to keep current)"
             )
-        else:
-            # No API key set
+        elif model_requires_api_key(llm.model, llm.base_url):
             self.api_key_input.placeholder = "Enter your API key"
+        else:
+            self.api_key_input.placeholder = "Optional for local or IAM-backed models"
 
         # Memory Condensation
         self.memory_select.value = bool(self.current_agent.condenser)
@@ -321,6 +326,11 @@ class SettingsScreen(ModalScreen):
             and self.current_agent.llm.api_key
         )
 
+    def _selected_model_requires_api_key(self) -> bool:
+        """Return whether the currently selected model requires an API key."""
+        model, base_url = self._get_selected_model_identity()
+        return model_requires_api_key(model, base_url)
+
     def _update_field_dependencies(self) -> None:
         """Update field enabled/disabled state based on dependency chain."""
         try:
@@ -386,15 +396,21 @@ class SettingsScreen(ModalScreen):
                 except Exception:
                     pass
 
-            # Memory Condensation: enabled when API key is provided
-            # or when there's an existing API key in the agent
-            self.memory_select.disabled = not (api_key or self._has_existing_api_key())
+            selected_model_requires_api_key = self._selected_model_requires_api_key()
+            has_required_auth = (
+                api_key
+                or self._has_existing_api_key()
+                or not selected_model_requires_api_key
+            )
+
+            # Memory Condensation: enabled when auth is satisfied for the
+            # selected model, whether via API key, stored credentials, or a
+            # local/IAM-backed provider that does not need an API key.
+            self.memory_select.disabled = not has_required_auth
 
             # Advanced LLM settings (timeout, max_tokens, max_size):
-            # Only enabled in Advanced mode and when API key is provided
-            advanced_settings_enabled = is_advanced_mode and (
-                api_key or self._has_existing_api_key()
-            )
+            # Only enabled in Advanced mode once auth requirements are satisfied.
+            advanced_settings_enabled = is_advanced_mode and has_required_auth
             self.timeout_input.disabled = not advanced_settings_enabled
             self.max_tokens_input.disabled = not advanced_settings_enabled
             self.max_size_input.disabled = not advanced_settings_enabled

--- a/openhands_cli/tui/modals/settings/utils.py
+++ b/openhands_cli/tui/modals/settings/utils.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, SecretStr, field_validator
 
 from openhands.sdk import LLM, Agent, LLMSummarizingCondenser
 from openhands_cli.stores import AgentStore
+from openhands_cli.stores.agent_store import model_requires_api_key
 from openhands_cli.utils import (
     get_default_cli_agent,
     get_llm_metadata,
@@ -151,8 +152,9 @@ class SettingsFormData(BaseModel):
             )
             self.api_key_input = existing_llm_api_key
 
-        if not self.api_key_input:
-            raise Exception("API Key is required")
+        if model_requires_api_key(self.get_full_model_name(), self.base_url):
+            if not self.api_key_input:
+                raise Exception("API Key is required")
 
     def get_full_model_name(self) -> str:
         if self.mode == "advanced":

--- a/tests/stores/test_env_llm_overrides.py
+++ b/tests/stores/test_env_llm_overrides.py
@@ -15,6 +15,7 @@ from openhands_cli.stores.agent_store import (
     MissingEnvironmentVariablesError,
     apply_llm_overrides,
     check_and_warn_env_vars,
+    model_requires_api_key,
 )
 
 
@@ -192,6 +193,42 @@ class TestLLMEnvOverrides:
         assert overrides.api_key is not None
         assert overrides.api_key.get_secret_value() == "explicit-key"
         assert overrides.model == "explicit-model"
+
+
+class TestHeadlessAuthRequirements:
+    """Tests for API-key requirements in headless mode."""
+
+    @pytest.mark.parametrize(
+        ("model", "base_url"),
+        [
+            ("ollama/llama3.3", None),
+            ("openai/gpt-4o-mini", "http://localhost:11434/v1"),
+            ("bedrock/anthropic.claude-sonnet-4-5", None),
+        ],
+    )
+    def test_require_for_headless_allows_no_api_key_for_supported_models(
+        self, model: str, base_url: str | None
+    ) -> None:
+        overrides = LLMEnvOverrides(model=model, base_url=base_url)
+        overrides.require_for_headless()
+
+    def test_require_for_headless_still_requires_api_key_for_remote_models(
+        self,
+    ) -> None:
+        overrides = LLMEnvOverrides(model="openai/gpt-4o")
+
+        with pytest.raises(MissingEnvironmentVariablesError) as exc_info:
+            overrides.require_for_headless()
+
+        assert exc_info.value.missing_vars == [ENV_LLM_API_KEY]
+
+    def test_model_requires_api_key_for_local_and_optional_auth_models(self) -> None:
+        assert model_requires_api_key("ollama/llama3.3") is False
+        assert (
+            model_requires_api_key("openai/gpt-4o-mini", "http://localhost:11434/v1")
+            is False
+        )
+        assert model_requires_api_key("openai/gpt-4o") is True
 
 
 class TestApplyLlmOverrides:
@@ -562,7 +599,6 @@ class TestAgentCreationFromEnvVars:
             with pytest.raises(MissingEnvironmentVariablesError) as exc_info:
                 store.load_or_create(env_overrides_enabled=True)
 
-            assert ENV_LLM_API_KEY in exc_info.value.missing_vars
             assert ENV_LLM_MODEL in exc_info.value.missing_vars
 
     def test_agent_returns_none_when_env_overrides_disabled(self, tmp_path) -> None:
@@ -592,6 +628,39 @@ class TestAgentCreationFromEnvVars:
 
             # Should return None since env overrides are disabled
             assert agent is None
+
+    def test_ensure_agent_allows_local_model_without_api_key(self, tmp_path) -> None:
+        """Headless agent creation should allow local models without LLM_API_KEY."""
+        from openhands_cli.stores import AgentStore
+
+        with patch(
+            "openhands_cli.stores.agent_store.get_persistence_dir",
+            return_value=str(tmp_path),
+        ):
+            store = AgentStore()
+
+        overrides = LLMEnvOverrides(model="ollama/llama3.3")
+
+        with (
+            patch(
+                "openhands_cli.stores.agent_store.LLM",
+                return_value="fake-llm",
+            ) as mock_llm,
+            patch(
+                "openhands_cli.stores.agent_store.get_default_cli_agent",
+                return_value="fake-agent",
+            ) as mock_get_default_cli_agent,
+        ):
+            agent = store._ensure_agent(None, overrides)
+
+        assert agent == "fake-agent"
+        mock_llm.assert_called_once_with(
+            model="ollama/llama3.3",
+            api_key=None,
+            base_url=None,
+            usage_id="agent",
+        )
+        mock_get_default_cli_agent.assert_called_once_with("fake-llm")
 
 
 class TestCriticBehaviorInAgentCreation:

--- a/tests/tui/modals/settings/test_settings_screen.py
+++ b/tests/tui/modals/settings/test_settings_screen.py
@@ -283,6 +283,44 @@ async def test_memory_condensation_disabled_when_no_api_key(
     assert screen.memory_select.disabled is True
 
 
+@pytest.mark.asyncio
+async def test_memory_condensation_enabled_for_ollama_without_api_key(app):
+    """Local providers should unlock optional fields without an API key."""
+    app_obj, _ = app
+    screen = app_obj.settings_screen
+    screen.current_agent = None
+    screen.mode_select.value = "basic"
+    screen.provider_select.value = "ollama"
+    screen.model_select.set_options([("llama3.3", "llama3.3")])
+    screen.model_select.value = "llama3.3"
+    screen.api_key_input.value = ""
+
+    screen._update_field_dependencies()
+
+    assert screen.api_key_input.disabled is False
+    assert screen.memory_select.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_advanced_settings_enabled_for_local_base_url_without_api_key(app):
+    """Advanced local endpoints should not lock optional settings behind an API key."""
+    app_obj, _ = app
+    screen = app_obj.settings_screen
+    screen.current_agent = None
+    screen.mode_select.value = "advanced"
+    screen.custom_model_input.value = "gpt-4o-mini"
+    screen.base_url_input.value = "http://localhost:11434/v1"
+    screen.api_key_input.value = ""
+
+    screen._update_field_dependencies()
+
+    assert screen.api_key_input.disabled is False
+    assert screen.memory_select.disabled is False
+    assert screen.timeout_input.disabled is False
+    assert screen.max_tokens_input.disabled is False
+    assert screen.max_size_input.disabled is False
+
+
 #
 # 3. Basic ↔ Advanced visibility toggling
 #

--- a/tests/tui/modals/settings/test_settings_utils.py
+++ b/tests/tui/modals/settings/test_settings_utils.py
@@ -243,6 +243,38 @@ def test_missing_api_key_errors_when_no_existing_agent() -> None:
     assert "API Key is required" in str(exc.value)
 
 
+def test_missing_api_key_allowed_for_ollama_provider() -> None:
+    """Ollama models should not require an API key in basic mode."""
+    data = settings_utils.SettingsFormData(
+        mode="basic",
+        provider="ollama",
+        model="llama3.3:70b",
+        custom_model=None,
+        base_url=None,
+        api_key_input=None,
+        memory_condensation_enabled=True,
+    )
+
+    data.resolve_data_fields(existing_agent=None)
+    assert data.api_key_input is None
+
+
+def test_missing_api_key_allowed_for_local_base_url() -> None:
+    """Local OpenAI-compatible endpoints should not require an API key."""
+    data = settings_utils.SettingsFormData(
+        mode="advanced",
+        provider=None,
+        model=None,
+        custom_model="gpt-4o-mini",
+        base_url="http://localhost:11434/v1",
+        api_key_input=None,
+        memory_condensation_enabled=True,
+    )
+
+    data.resolve_data_fields(existing_agent=None)
+    assert data.api_key_input is None
+
+
 def test_save_settings_wraps_errors_into_result(deps: FakeAgentStore) -> None:
     """save_settings should surface resolver errors as success=False."""
     # Invalid: advanced mode with missing custom_model/base_url


### PR DESCRIPTION
## Summary
- skip API key validation for local or IAM-backed models in CLI settings
- unlock memory condensation and advanced settings for Ollama or localhost-backed models
- allow `--override-with-envs` to create agents for local/Ollama models without `LLM_API_KEY`

## Testing
- `uv run ruff check openhands_cli/stores/agent_store.py openhands_cli/tui/modals/settings/utils.py openhands_cli/tui/modals/settings/settings_screen.py tests/stores/test_env_llm_overrides.py tests/tui/modals/settings/test_settings_utils.py tests/tui/modals/settings/test_settings_screen.py`
- `uv run pytest -q tests/stores/test_env_llm_overrides.py tests/tui/modals/settings/test_settings_utils.py tests/tui/modals/settings/test_settings_screen.py`

Fixes #673