### PR TITLE
chore: Move good-first-issue labeler to SDK script for smaller blast radius

### DIFF
--- a/.github/scripts/good_first_issue_labeler.py
+++ b/.github/scripts/good_first_issue_labeler.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "openhands-sdk",
+#   "httpx",
+# ]
+# ///
+"""Agent that applies the 'good first issue' label to qualifying GitHub issues.
+
+The agent follows the rules in .github/prompts/good-first-issue-labeler.md.
+Tools: a whitelisted GitHub REST API tool, GlobTool, and PlanningFileEditorTool.
+
+Usage
+-----
+    uv run .github/scripts/good_first_issue_labeler.py
+
+Required environment variables
+-------------------------------
+    GITHUB_TOKEN   GitHub personal access token with repo label-write permissions
+    LLM_API_KEY    API key for the LLM provider
+
+Optional environment variables
+--------------------------------
+    LLM_MODEL      LiteLLM model string  (default: anthropic/claude-sonnet-4-5-20250929)
+    LLM_BASE_URL   Override base URL for the LLM provider
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import httpx
+from pydantic import Field
+
+from openhands.sdk import (
+    LLM,
+    Action,
+    Agent,
+    Conversation,
+    ImageContent,
+    Observation,
+    TextContent,
+    ToolDefinition,
+)
+from openhands.sdk.tool import Tool, ToolAnnotations, ToolExecutor, register_tool
+from openhands.tools.glob import GlobTool
+from openhands.tools.planning_file_editor import PlanningFileEditorTool
+
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+# =============================================================================
+# Tool 1 — GitHub REST API (whitelisted)
+# =============================================================================
+# Provides authenticated access to the GitHub API, restricted to the exact
+# (method, path) pairs in _ALLOWED_ENDPOINTS.  The httpx.Client is
+# instantiated once and reused across calls (connection pooling, keep-alive).
+# =============================================================================
+
+
+class GitHubAPIAction(Action):
+    method: str = Field(description="HTTP method: GET, POST, PATCH, PUT, DELETE")
+    endpoint: str = Field(
+        description=(
+            "GitHub API path (no base URL), e.g. "
+            "/repos/OpenHands/OpenHands-CLI/issues or "
+            "/search/issues"
+        )
+    )
+    params: dict | None = Field(default=None, description="Query-string parameters")
+    body: dict | None = Field(
+        default=None, description="JSON request body for POST/PATCH/PUT"
+    )
+
+
+class GitHubAPIObservation(Observation):
+    status_code: int = Field(description="HTTP response status code")
+    data: dict | list | str | None = Field(default=None, description="Parsed JSON body")
+    error: str | None = Field(default=None, description="Transport or decode error")
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
+        if self.error:
+            return [TextContent(text=f"GitHub API error: {self.error}")]
+        body = (
+            json.dumps(self.data, indent=2)
+            if not isinstance(self.data, str)
+            else self.data
+        )
+        return [TextContent(text=f"HTTP {self.status_code}\n{body[:8000]}")]
+
+
+# Explicit allowlist of (METHOD, compiled-regex) pairs the agent may call.
+# [^/]+ matches exactly one path segment — it cannot cross a '/' boundary.
+_ALLOWED_ENDPOINTS: list[tuple[str, re.Pattern[str]]] = [
+    ("GET", re.compile(r"^/search/issues$")),
+    ("GET", re.compile(r"^/repos/OpenHands/OpenHands-CLI/issues$")),
+    ("GET", re.compile(r"^/repos/OpenHands/OpenHands-CLI/issues/[^/]+$")),
+    ("GET", re.compile(r"^/repos/OpenHands/OpenHands-CLI/labels$")),
+    ("POST", re.compile(r"^/repos/OpenHands/OpenHands-CLI/labels$")),
+    ("POST", re.compile(r"^/repos/OpenHands/OpenHands-CLI/issues/[^/]+/labels$")),
+]
+
+
+def _is_allowed(method: str, endpoint: str) -> bool:
+    return any(
+        method.upper() == m and bool(p.fullmatch(endpoint))
+        for m, p in _ALLOWED_ENDPOINTS
+    )
+
+
+class GitHubAPIExecutor(ToolExecutor[GitHubAPIAction, GitHubAPIObservation]):
+    def __init__(self, token: str) -> None:
+        self._client = httpx.Client(
+            base_url="https://api.github.com",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30,
+        )
+
+    def __call__(
+        self,
+        action: GitHubAPIAction,
+        conversation=None,  # noqa: ARG002
+    ) -> GitHubAPIObservation:
+        if not _is_allowed(action.method, action.endpoint):
+            return GitHubAPIObservation(
+                status_code=403,
+                error=(
+                    f"{action.method.upper()} {action.endpoint} is not in the "
+                    "allowed endpoint list."
+                ),
+            )
+        try:
+            resp = self._client.request(
+                action.method.upper(),
+                action.endpoint,
+                params=action.params,
+                json=action.body,
+            )
+            try:
+                data = resp.json()
+            except Exception:
+                data = resp.text
+            return GitHubAPIObservation(status_code=resp.status_code, data=data)
+        except Exception as exc:
+            return GitHubAPIObservation(status_code=0, error=str(exc))
+
+    def close(self) -> None:
+        self._client.close()
+
+
+_GITHUB_API_DESCRIPTION = """\
+Make authenticated GitHub REST API calls. The token is pre-configured.
+
+Typical operations
+------------------
+Search recent open issues (last 7 days):
+  method=GET
+  endpoint=/search/issues
+  params={"q": "repo:OpenHands/OpenHands-CLI is:issue is:open created:>=YYYY-MM-DD"}
+
+Fetch a single issue:
+  method=GET  endpoint=/repos/OpenHands/OpenHands-CLI/issues/{number}
+
+List repo labels:
+  method=GET  endpoint=/repos/OpenHands/OpenHands-CLI/labels
+
+Create a label (if missing):
+  method=POST  endpoint=/repos/OpenHands/OpenHands-CLI/labels
+  body={"name": "good first issue", "color": "7057ff",
+        "description": "Good first issue for new contributors"}
+
+Apply labels to an issue:
+  method=POST  endpoint=/repos/OpenHands/OpenHands-CLI/issues/{number}/labels
+  body={"labels": ["good first issue"]}
+
+Paginate with params={"page": 2, "per_page": 100} when needed.
+"""
+
+
+class GitHubAPITool(ToolDefinition[GitHubAPIAction, GitHubAPIObservation]):
+    """Authenticated GitHub REST API — read + label operations."""
+
+    @classmethod
+    def create(cls, conv_state, **_) -> Sequence[ToolDefinition]:  # noqa: ARG003
+        token = os.environ.get("GITHUB_TOKEN", "")
+        return [
+            cls(
+                description=_GITHUB_API_DESCRIPTION,
+                action_type=GitHubAPIAction,
+                observation_type=GitHubAPIObservation,
+                executor=GitHubAPIExecutor(token=token),
+                annotations=ToolAnnotations(
+                    readOnlyHint=False,  # can POST (create label / apply label)
+                    destructiveHint=False,
+                    idempotentHint=False,
+                    openWorldHint=True,  # talks to external GitHub API
+                ),
+            )
+        ]
+
+
+register_tool(GitHubAPITool.name, GitHubAPITool)
+
+
+# =============================================================================
+# Tools 2 & 3 — Read-only working-directory file access
+# =============================================================================
+# GlobTool and PlanningFileEditorTool are imported above; importing them
+# auto-registers them with the SDK tool registry.  No extra code needed.
+# =============================================================================
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+def _load_prompt(repo_root: Path) -> str:
+    prompt_path = repo_root / ".github" / "prompts" / "good-first-issue-labeler.md"
+    if not prompt_path.exists():
+        sys.exit(f"Prompt file not found: {prompt_path}")
+    return prompt_path.read_text()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Label qualifying GitHub issues as 'good first issue'.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(_REPO_ROOT),
+        metavar="DIR",
+        help="Repository root directory (default: parent of .github/).",
+    )
+    args = parser.parse_args()
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        sys.exit("Error: GITHUB_TOKEN environment variable is required.")
+
+    llm_api_key = os.environ.get("LLM_API_KEY")
+    if not llm_api_key:
+        sys.exit("Error: LLM_API_KEY environment variable is required.")
+
+    llm = LLM(
+        model=os.environ.get("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+        api_key=llm_api_key,
+        base_url=os.environ.get("LLM_BASE_URL"),
+    )
+
+    tools = [
+        Tool(name=GitHubAPITool.name),
+        Tool(name=GlobTool.name),
+        Tool(name=PlanningFileEditorTool.name),
+    ]
+
+    agent = Agent(llm=llm, tools=tools)
+
+    repo_root = Path(args.repo_root).resolve()
+    prompt = _load_prompt(repo_root)
+
+    conversation = Conversation(agent=agent, workspace=str(repo_root))
+    conversation.send_message(prompt)
+    conversation.run()
+
+    cost = llm.metrics.accumulated_cost
+    print(f"\nDone. Accumulated LLM cost: ${cost:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/good_first_issue_labeler.py
+++ b/.github/scripts/good_first_issue_labeler.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "openhands-sdk",
+#   "openhands-tools",
 #   "httpx",
 # ]
 # ///

--- a/.github/workflows/good-first-issue-labeler.yml
+++ b/.github/workflows/good-first-issue-labeler.yml
@@ -33,16 +33,11 @@ jobs:
                   # Disable uv caching to reduce cross-workflow cache poisoning risk.
                   enable-cache: false
 
-            - name: Install dependencies
-              run: |
-                  uv sync --group dev
-
-            - name: Run OpenHands labeler
+            - name: Run labeler
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
                   LLM_BASE_URL: https://llm-proxy.app.all-hands.dev
                   LLM_MODEL: litellm_proxy/gpt-5.2
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  uv run openhands --headless --always-approve --override-with-envs \
-                    --file .github/prompts/good-first-issue-labeler.md || echo "OpenHands labeling completed"
+                  uv run .github/scripts/good_first_issue_labeler.py

--- a/tests/test_good_first_issue_labeler.py
+++ b/tests/test_good_first_issue_labeler.py
@@ -1,0 +1,49 @@
+"""Tests for .github/scripts/good-first-issue-labeler.py"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = Path(__file__).parent.parent / ".github/scripts/good_first_issue_labeler.py"
+
+
+@pytest.fixture(scope="module")
+def labeler():
+    spec = importlib.util.spec_from_file_location("good_first_issue_labeler", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_load_prompt_from_default_repo_root(labeler):
+    """_load_prompt must succeed using the default _REPO_ROOT."""
+    prompt = labeler._load_prompt(labeler._REPO_ROOT)
+    assert prompt.strip()
+
+
+@pytest.mark.parametrize(
+    "method,endpoint,expected",
+    [
+        # Allowed — every operation the prompt requires
+        ("GET", "/search/issues", True),
+        ("GET", "/repos/OpenHands/OpenHands-CLI/issues", True),
+        ("GET", "/repos/OpenHands/OpenHands-CLI/issues/42", True),
+        ("GET", "/repos/OpenHands/OpenHands-CLI/labels", True),
+        ("POST", "/repos/OpenHands/OpenHands-CLI/labels", True),
+        ("POST", "/repos/OpenHands/OpenHands-CLI/issues/42/labels", True),
+        # Blocked — mutating or out-of-scope operations
+        ("DELETE", "/repos/OpenHands/OpenHands-CLI/issues/42", False),
+        ("PATCH", "/repos/OpenHands/OpenHands-CLI/issues/42", False),
+        ("POST", "/repos/OpenHands/OpenHands-CLI/issues/42/comments", False),
+        ("GET", "/repos/OpenHands/OpenHands-CLI/git/refs", False),
+        ("DELETE", "/repos/OpenHands/OpenHands-CLI/labels/good+first", False),
+        # Blocked — multi-segment paths that fnmatch '*' would have matched
+        ("GET", "/repos/OpenHands/OpenHands-CLI/issues/42/comments", False),
+        ("POST", "/repos/OpenHands/OpenHands-CLI/issues/42/extra/labels", False),
+    ],
+)
+def test_is_allowed(labeler, method, endpoint, expected):
+    assert labeler._is_allowed(method, endpoint) is expected


### PR DESCRIPTION
Human:
As investigated in #519, GitHub Actions that use an agent to process triage issues are a vector for prompt injection. This can be mitigated by restricting the agent's tool access. This PR runs the same "good first issue" prompt using an SDK script with minimal tools, replacing the default headless CLI which has full terminal access.

Evidence of running in first comment.

# Agent Summary

## What changed

Replaces the `openhands --headless` invocation in the weekly labeler workflow with a purpose-built agent SDK UV script.

### New files

**`.github/scripts/good_first_issue_labeler.py`** — PEP 723 inline-deps UV script that:
- Reads the existing prompt from `.github/prompts/good-first-issue-labeler.md`
- Gives the agent three tools: a whitelisted GitHub REST API tool, `GlobTool`, and `PlanningFileEditorTool`
- GitHub API tool enforces an allowlist of `(METHOD, compiled-regex)` pairs; wildcards use `[^/]+` so they cannot cross path-segment boundaries (e.g. `GET …/issues/42/comments` is blocked, not silently allowed by a glob `*`)

**`tests/test_good_first_issue_labeler.py`** — covers:
- `_load_prompt(_REPO_ROOT)` succeeds and returns content (catches a wrong parent-depth bug that would `sys.exit` on every run)
- `_is_allowed` for every operation the prompt requires (6 allowed) plus mutations and multi-segment paths that a naive `fnmatch` allowlist would have passed (13 cases total)

### Modified

**`.github/workflows/good-first-issue-labeler.yml`** — drops the `uv sync` step (the script is self-contained via PEP 723 inline deps) and runs `uv run .github/scripts/good_first_issue_labeler.py` directly.

## Why

The old workflow called `openhands --headless --always-approve --file <prompt>` which gives the agent the full default toolset with no API surface restriction. The new script:
- Limits the agent to exactly the GitHub API calls the prompt needs
- Adds file-read tools (`GlobTool`, `PlanningFileEditorTool`) so the agent can reference repo context without shell access
- Is testable in CI (the whitelist logic and prompt loading are unit-tested)
- Is self-documenting (`uv run .github/scripts/good_first_issue_labeler.py --help`)

## Commands run

```
make lint        # pre-commit run --all-files
make test        # pytest -v --ignore=tests/snapshots
```

Pre-commit output (ruff format, ruff lint, pycodestyle, pyright): all passed.
Test output: 14 passed, 5 warnings.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@raymyers can click here to [continue refining the PR](https://app.all-hands.dev/conversations/69a69b5f-d62a-40cc-b375-fc8d2c100ff1)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@feat/good-first-issue-labeler-sdk-script
```