### PR TITLE
feat: support custom session_id via ACP _meta field in new_session()

### DIFF
--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -456,7 +456,13 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             is_resuming = True
             logger.info(f"Resuming conversation: {session_id}")
         else:
-            session_id = str(uuid.uuid4())
+            # Allow clients to pass a custom session_id via ACP-standard _meta field.
+            # This enables deterministic conversation IDs for resume/persistence use cases.
+            _meta = _kwargs.get("_meta") or {}
+            custom_session_id = _meta.get("session_id")
+            session_id = str(custom_session_id) if custom_session_id else str(uuid.uuid4())
+            if custom_session_id:
+                logger.info(f"Using custom session ID: {session_id}")
 
         try:
             conversation = await self._get_or_create_conversation(


### PR DESCRIPTION
## Summary

Allows ACP clients to pass a deterministic `session_id` through the standard ACP `_meta` extensibility field in `session/new` requests. When `_meta` contains a `session_id` key, the agent uses it instead of generating a random UUID.

## Motivation

ACP clients (like Virtual Team orchestrators or CI pipelines) need deterministic session IDs to:
- Persist and resume conversations across process restarts
- Map agent conversations to external task IDs
- Keep the ACP process alive while switching between multiple role-specific conversations

Currently, `session/new` always generates a random UUID, giving the client no control over the session identity.

## Change

**File:** `openhands_cli/acp_impl/agent/base_agent.py` — `new_session()` method

```python
# Before:
else:
    session_id = str(uuid.uuid4())

# After:
else:
    _meta = _kwargs.get("_meta") or {}
    custom_session_id = _meta.get("session_id")
    session_id = str(custom_session_id) if custom_session_id else str(uuid.uuid4())
```

7 lines inserted, 1 deleted. Purely additive — all existing behavior is preserved when `_meta` is absent. The `_meta` field is already part of the ACP protocol spec and collected by the `NewSessionRequest` schema.

## Usage

ACP clients can now send:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "session/new",
  "params": {
    "cwd": "/workspace",
    "_meta": {
      "session_id": "my-task-id-001"
    }
  }
}
```

## Testing

- Existing behavior unchanged when `_meta` is absent (random UUID continues)
- Manual test confirmed: custom session_id passed via `_meta` is used as the conversation ID
- Conversation persistence dir created at `~/.openhands/conversations/{custom_id}.hex/` as expected