### PR TITLE
ci: add label-triggered OpenHands QA workflow

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -1,0 +1,41 @@
+---
+# Automated QA validation of PR changes using OpenHands.
+#
+# This workflow runs only when the `qa-this` label is added to a same-repo PR.
+# Unlike code review, the QA agent executes the changed code and posts a
+# functional verification report.
+name: QA Changes by OpenHands
+
+on:
+    pull_request:
+        types: [labeled]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    qa-changes:
+        # Only run for same-repo PRs (secrets are not available to forks), and
+        # only when explicitly triggered by the `qa-this` label.
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.label.name == 'qa-this'
+        concurrency:
+            group: qa-changes-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        steps:
+            - name: Run QA Changes
+              uses: OpenHands/extensions/plugins/qa-changes@main
+              with:
+                  llm-model: litellm_proxy/openai/gpt-5.5
+                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  max-budget: '10.0'
+                  timeout-minutes: '30'
+                  max-iterations: '500'
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
+                  lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

- Add a `QA Changes by OpenHands` workflow adapted from the OpenHands QA Changes plugin.
- Trigger it only when the `qa-this` label is added to a same-repo PR.
- Use the OpenHands LLM proxy and bot token secrets for the QA action.

## Validation

- `uv run pre-commit run --files .github/workflows/qa-changes-by-openhands.yml`

## Notes

Created the `qa-this` repository label with orange color `FF8C00` and description `Trigger OpenHands QA validation`.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e948c79b-6548-44f4-b8af-ab71970dc27d)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@add-qa-changes-workflow
```